### PR TITLE
Remove support for a single column "core experience"

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,36 +265,6 @@ To create styles that respond to the same breakpoints as the grid, this Sass mix
 
 It relies on [Sass MQ](http://git.io/sass-mq) to output mobile-first @media queries.
 
-#### Serve layout rules to modern browsers and IE 8 only
-
-Typically, you'd want older browsers to show no layout at all,
-only stacked full-width columns.
-
-To serve layout rules to IE 8 and modern browsers only, scope them inside
-the `oGridRules` helper:
-
-```scss
-@include oGridRules { // Prevents from serving layout in the core experience
-	el {
-		width: oGridColspan(8);
-	}
-}
-```
-
-Outputs:
-
-```scss
-@media \0screen { // IE8 only
-	el {
-		width: 66.666666667%;
-	}
-}
-@media screen only { // Modern browsers only
-	el {
-		width: 66.666666667%;
-	}
-}
-```
 
 #### *Unstyle* a row or a column
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ It supports browsers with support for *CSS @media queries* and *box-sizing*.
 [Report a bug](https://github.com/Financial-Times/o-grid/issues)
 
 ## Browser support
-This module has been verified in Internet Explorer 8+, modern desktop browsers (Chrome, Safari, Firefox, ...) and mobile browsers (Android browser, iOS safari, Chrome mobile).
+This module has been verified in Internet Explorer 8+, modern desktop browsers (Chrome, Safari, Firefox, …) and mobile browsers (Android browser, iOS safari, Chrome mobile).
+
+Older browsers: you may use a [box-sizing polyfill](https://github.com/Schepp/box-sizing-polyfill) to support give better support to IE < 8.
 
 ### Grid dimensions
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## About
 
 o-grid defines a 12 column responsive, nestable grid system for laying out HTML pages and modules.
-It supports all browsers with support for *CSS @media queries*, with fixed-width fallback for older browsers.
+It supports browsers with support for *CSS @media queries* and *box-sizing*.
 
 > Living off the grid and being kind of an outlaw brings a dangerous reality.  
   *Ron Perlman*
@@ -11,7 +11,7 @@ It supports all browsers with support for *CSS @media queries*, with fixed-width
 [Report a bug](https://github.com/Financial-Times/o-grid/issues)
 
 ## Browser support
-This module has been verified in Internet Explorer 7+, modern desktop browsers (Chrome, Safari, Firefox, ...) and mobile browsers (Android browser, iOS safari, Chrome mobile).
+This module has been verified in Internet Explorer 8+, modern desktop browsers (Chrome, Safari, Firefox, ...) and mobile browsers (Android browser, iOS safari, Chrome mobile).
 
 ### Grid dimensions
 

--- a/demos/always-fixed.html
+++ b/demos/always-fixed.html
@@ -74,8 +74,8 @@
 			<div class="demo-cell">
 				4 S12 M4
 				<div class="o-grid-row demo-row">
-					<div data-o-grid-colspan="12 L6 XL6"><div class="demo-cell">12 L6 XL6</div></div>
-					<div data-o-grid-colspan="12 L6 XL6"><div class="demo-cell">12 L6 XL6</div></div>
+					<div data-o-grid-colspan="12 L7 XL6"><div class="demo-cell">12 L7 XL6</div></div>
+					<div data-o-grid-colspan="12 L5 XL6"><div class="demo-cell">12 L5 XL6</div></div>
 				</div>
 			</div>
 		</div>

--- a/demos/core-experience.html
+++ b/demos/core-experience.html
@@ -74,8 +74,8 @@
 			<div class="demo-cell">
 				4 S12 M4
 				<div class="o-grid-row demo-row">
-					<div data-o-grid-colspan="12 L6 XL6"><div class="demo-cell">12 L6 XL6</div></div>
-					<div data-o-grid-colspan="12 L6 XL6"><div class="demo-cell">12 L6 XL6</div></div>
+					<div data-o-grid-colspan="12 L7 XL6"><div class="demo-cell">12 L7 XL6</div></div>
+					<div data-o-grid-colspan="12 L5 XL6"><div class="demo-cell">12 L5 XL6</div></div>
 				</div>
 			</div>
 		</div>

--- a/demos/default.html
+++ b/demos/default.html
@@ -74,8 +74,8 @@
 			<div class="demo-cell">
 				4 S12 M4
 				<div class="o-grid-row demo-row">
-					<div data-o-grid-colspan="12 L6 XL6"><div class="demo-cell">12 L6 XL6</div></div>
-					<div data-o-grid-colspan="12 L6 XL6"><div class="demo-cell">12 L6 XL6</div></div>
+					<div data-o-grid-colspan="12 L7 XL6"><div class="demo-cell">12 L7 XL6</div></div>
+					<div data-o-grid-colspan="12 L5 XL6"><div class="demo-cell">12 L5 XL6</div></div>
 				</div>
 			</div>
 		</div>

--- a/demos/ie8.html
+++ b/demos/ie8.html
@@ -74,8 +74,8 @@
 			<div class="demo-cell">
 				4 S12 M4
 				<div class="o-grid-row demo-row">
-					<div data-o-grid-colspan="12 L6 XL6"><div class="demo-cell">12 L6 XL6</div></div>
-					<div data-o-grid-colspan="12 L6 XL6"><div class="demo-cell">12 L6 XL6</div></div>
+					<div data-o-grid-colspan="12 L7 XL6"><div class="demo-cell">12 L7 XL6</div></div>
+					<div data-o-grid-colspan="12 L5 XL6"><div class="demo-cell">12 L5 XL6</div></div>
 				</div>
 			</div>
 		</div>

--- a/demos/resized.html
+++ b/demos/resized.html
@@ -74,8 +74,8 @@
 			<div class="demo-cell">
 				4 S12 M4
 				<div class="o-grid-row demo-row">
-					<div data-o-grid-colspan="12 L6 XL6"><div class="demo-cell">12 L6 XL6</div></div>
-					<div data-o-grid-colspan="12 L6 XL6"><div class="demo-cell">12 L6 XL6</div></div>
+					<div data-o-grid-colspan="12 L7 XL6"><div class="demo-cell">12 L7 XL6</div></div>
+					<div data-o-grid-colspan="12 L5 XL6"><div class="demo-cell">12 L5 XL6</div></div>
 				</div>
 			</div>
 		</div>

--- a/demos/snappy.html
+++ b/demos/snappy.html
@@ -74,8 +74,8 @@
 			<div class="demo-cell">
 				4 S12 M4
 				<div class="o-grid-row demo-row">
-					<div data-o-grid-colspan="12 L6 XL6"><div class="demo-cell">12 L6 XL6</div></div>
-					<div data-o-grid-colspan="12 L6 XL6"><div class="demo-cell">12 L6 XL6</div></div>
+					<div data-o-grid-colspan="12 L7 XL6"><div class="demo-cell">12 L7 XL6</div></div>
+					<div data-o-grid-colspan="12 L5 XL6"><div class="demo-cell">12 L5 XL6</div></div>
 				</div>
 			</div>
 		</div>

--- a/demos/src/configurations.json
+++ b/demos/src/configurations.json
@@ -3,6 +3,5 @@
 	"snappy": "Responsive grid that snaps between a larger fixed layout at each breakpoint",
 	"resized": "Responsive grid with breakpoints reallocated to 400px, 800px and 1000px and gutters halved",
 	"always-fixed": "Fixed grid at 610px across all browsers and devices.  Should always be fixed at the large layout",
-	"core-experience": "Forced core experience, where all columns stack on top of each other",
 	"ie8": "Forced IE 8 experience, where the width of the grid is fixed to be a M layout"
 }

--- a/demos/src/js/style-switcher.js
+++ b/demos/src/js/style-switcher.js
@@ -86,15 +86,6 @@ if (![].includes) {
 }());
 
 function getExpectedSpans(el) {
-	// In core experience, a column is either full-width or hidden
-	if (document.documentElement.className.includes('core-experience')) {
-		// Check if data-o-grid-colspan="0…" or data-o-grid-colspan="hide…"
-		if (/\b0|hide\b/.test(el.dataset.oGridColspan)) {
-			return 0;
-		}
-		return 12;
-	}
-
 	var layout = getCurrentLayout();
 
 	var rules = el.dataset.oGridColspan;
@@ -114,11 +105,6 @@ function getExpectedSpans(el) {
 
 // Get offset, pull, push
 function getExpectedModifier(el, modifier) {
-	// In core experience, a column is never, pulled, pushed nor has an offset
-	if (document.documentElement.className.includes('core-experience')) {
-		return 0;
-	}
-
 	var rules = el.dataset.oGridColspan;
 	var re = new RegExp(modifier, "g");
 
@@ -147,10 +133,6 @@ function getExpectedModifier(el, modifier) {
 }
 
 function getExpectedGutter(el, side) {
-	if (document.documentElement.className.includes('core-experience')) {
-		return true; // Core experience always has gutters
-	}
-
 	var layout = getCurrentLayout();
 
 	var gutterClassName = 'o-grid-remove-gutters';
@@ -186,10 +168,6 @@ function highlightUnexpectedGutter(el) {
 
 
 function getExpectedMargin(el, side) {
-	if (document.documentElement.className.includes('core-experience')) {
-		return 0; // Core experience never has margins
-	}
-
 	var layout = getCurrentLayout();
 
 	var centerModifier = 'center';
@@ -259,10 +237,6 @@ function highlightUnexpectedWidth(el) {
 
 	if ($(el).parents('.o-grid-row--compact').length > 0) {
 		outerMargins = 0;
-	}
-
-	if (document.documentElement.className.includes('core-experience')) {
-		outerMargins = 10; // Restore default margins if column is in a compact row
 	}
 
 	// If the element is in a nested row,

--- a/demos/src/layout.mustache
+++ b/demos/src/layout.mustache
@@ -59,8 +59,8 @@
 			<div class="demo-cell">
 				4 S12 M4
 				<div class="o-grid-row demo-row">
-					<div data-o-grid-colspan="12 L6 XL6"><div class="demo-cell">12 L6 XL6</div></div>
-					<div data-o-grid-colspan="12 L6 XL6"><div class="demo-cell">12 L6 XL6</div></div>
+					<div data-o-grid-colspan="12 L7 XL6"><div class="demo-cell">12 L7 XL6</div></div>
+					<div data-o-grid-colspan="12 L5 XL6"><div class="demo-cell">12 L5 XL6</div></div>
 				</div>
 			</div>
 		</div>

--- a/demos/src/scss/_demos.scss
+++ b/demos/src/scss/_demos.scss
@@ -36,4 +36,11 @@ body {
 	h2 {
 		@include oGridRow;
 	}
+	// Display configuration information
+	&:before {
+		display: block;
+		text-align: center;
+		font-family: monaco, monospace;
+		padding-top: 4px;
+	}
 }

--- a/demos/src/scss/always-fixed.scss
+++ b/demos/src/scss/always-fixed.scss
@@ -2,3 +2,7 @@ $o-grid-mode: 'fixed';
 $o-grid-fixed-layout: 'S';
 
 @import "common";
+
+.demo:before {
+	content: '$o-grid-fixed-layout: #{$o-grid-fixed-layout}, $o-grid-mode: #{$o-grid-mode}';
+}

--- a/demos/src/scss/core-experience.scss
+++ b/demos/src/scss/core-experience.scss
@@ -1,4 +1,0 @@
-// Disable enhanced experience, forcing the core experience instead
-$o-grid-enable-enhanced-experience: false;
-
-@import "common";

--- a/demos/src/scss/ie8.scss
+++ b/demos/src/scss/ie8.scss
@@ -4,12 +4,6 @@ $o-grid-ie8-rules: 'only';
 
 @import "common";
 
-@include oGridTargetModernBrowsers {
-	.o-grid-row {
-		width: oGridGetMaxWidthForLayout($o-grid-fixed-layout);
-
-		.o-grid-row {
-			width: auto;
-		}
-	}
+.demo:before {
+	content: '$o-grid-fixed-layout: #{$o-grid-fixed-layout}, $o-grid-mode: #{$o-grid-mode}, $o-grid-ie8-rules: #{$o-grid-ie8-rules}';
 }

--- a/demos/src/scss/ie8.scss
+++ b/demos/src/scss/ie8.scss
@@ -1,9 +1,8 @@
 $o-grid-mode: 'fixed';
-$o-grid-fixed-layout: 'M';
 $o-grid-ie8-rules: 'only';
 
 @import "common";
 
 .demo:before {
-	content: '$o-grid-fixed-layout: #{$o-grid-fixed-layout}, $o-grid-mode: #{$o-grid-mode}, $o-grid-ie8-rules: #{$o-grid-ie8-rules}';
+	content: '$o-grid-fixed-layout: #{$o-grid-fixed-layout} (default), $o-grid-mode: #{$o-grid-mode}, $o-grid-ie8-rules: #{$o-grid-ie8-rules}';
 }

--- a/demos/src/scss/resized.scss
+++ b/demos/src/scss/resized.scss
@@ -7,3 +7,7 @@ $o-grid-layouts: (
 $o-grid-gutter: 5px;
 
 @import 'common';
+
+.demo:before {
+	content: '$o-grid-gutter: #{$o-grid-gutter}, $o-grid-layouts: S: 400px, M: 800px, L: 1000px';
+}

--- a/demos/src/scss/snappy.scss
+++ b/demos/src/scss/snappy.scss
@@ -1,3 +1,7 @@
 $o-grid-mode: 'snappy';
 
 @import "common";
+
+.demo:before {
+	content: '$o-grid-mode: #{$o-grid-mode}';
+}

--- a/origami.json
+++ b/origami.json
@@ -31,11 +31,6 @@
             "description": "Fixed grid at 610px across all browsers and devices.  Should always be fixed at the large layout"
         },
         {
-            "path": "/demos/core-experience.html",
-            "expanded": false,
-            "description": "Forced core experience, where all columns stack on top of each other"
-        },
-        {
             "path": "/demos/ie8.html",
             "expanded": false,
             "description": "Forced IE 8 experience, where the width of the grid is fixed to be a M layout"

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -164,44 +164,42 @@
 		display: none;
 	}
 
-	@if $o-grid-enable-enhanced-experience {
-		// Center and un-center
-		[data-o-grid-colspan~="#{$layout-name}center"] {
-			@include oGridCenter;
+	// Center and un-center
+	[data-o-grid-colspan~="#{$layout-name}center"] {
+		@include oGridCenter;
+	}
+	// Only output "uncenter" modifier with a layout (e.g. XLuncenter)
+	@if $layout-name != null {
+		[data-o-grid-colspan~="#{$layout-name}uncenter"] {
+			@include oGridUncenter;
 		}
-		// Only output "uncenter" modifier with a layout (e.g. XLuncenter)
-		@if $layout-name != null {
-			[data-o-grid-colspan~="#{$layout-name}uncenter"] {
-				@include oGridUncenter;
-			}
-		}
+	}
 
-		// Pull, push, offset
-		@for $colspan from 0 through ($o-grid-columns - 1) {
-			[data-o-grid-colspan~="#{$layout-name}push#{$colspan}"] {
-				@include oGridPush($colspan);
-			}
-			[data-o-grid-colspan~="#{$layout-name}pull#{$colspan}"] {
-				@include oGridPull($colspan);
-			}
-			[data-o-grid-colspan~="#{$layout-name}offset#{$colspan}"] {
-				@include oGridOffset($colspan);
-			}
+	// Pull, push, offset
+	@for $colspan from 0 through ($o-grid-columns - 1) {
+		[data-o-grid-colspan~="#{$layout-name}push#{$colspan}"] {
+			@include oGridPush($colspan);
 		}
+		[data-o-grid-colspan~="#{$layout-name}pull#{$colspan}"] {
+			@include oGridPull($colspan);
+		}
+		[data-o-grid-colspan~="#{$layout-name}offset#{$colspan}"] {
+			@include oGridOffset($colspan);
+		}
+	}
 
-		// Portions
-		@each $human-friendly-name in (full-width, one-half, one-third, two-thirds, one-quarter, three-quarters) {
-			[data-o-grid-colspan~="#{$layout-name}#{$human-friendly-name}"] {
-				// Restore visibility from `display: none`
-				// if `data-o-grid-colspan` was set to `0` or `hide`
-				display: block;
-				width: oGridColspan($human-friendly-name);
-			}
+	// Portions
+	@each $human-friendly-name in (full-width, one-half, one-third, two-thirds, one-quarter, three-quarters) {
+		[data-o-grid-colspan~="#{$layout-name}#{$human-friendly-name}"] {
+			// Restore visibility from `display: none`
+			// if `data-o-grid-colspan` was set to `0` or `hide`
+			display: block;
+			width: oGridColspan($human-friendly-name);
 		}
 	}
 }
 
-/// Base column styles for the enhanced experience
+/// Base column styles
 ///
 /// @example scss
 ///   el { @include oGridColumn; }
@@ -210,29 +208,13 @@
 ///   el { @include oGridColumn((default: 12, M: 8, L: hide)); }
 ///
 /// @param {Number | Map} $layouts [null]
-/// @param {String} $experience [null]
-@mixin oGridColumn($span: null, $experience: null) {
-	@if $experience == 'core' {
-		position: relative; // Required for push and pull
-		padding-left: $o-grid-gutter / 2;
-		padding-right: $o-grid-gutter / 2;
-	}
-	@if $o-grid-enable-enhanced-experience {
-		@if $experience == 'enhanced' {
-			float: left;
-			box-sizing: border-box;
-		}
-	}
-	@if $experience == null {
-		@include oGridColumn($experience: 'core');
+@mixin oGridColumn($span: null) {
+	position: relative; // Required for push and pull
+	padding-left: $o-grid-gutter / 2;
+	padding-right: $o-grid-gutter / 2;
+	float: left;
+	box-sizing: border-box;
 
-		@include oGridTargetIE8 {
-			@include oGridColumn($experience: 'enhanced');
-		}
-		@include oGridTargetModernBrowsers {
-			@include oGridColumn($experience: 'enhanced');
-		}
-	}
 	@if $span {
 		@include oGridColspan($span);
 	}
@@ -312,90 +294,74 @@
 
 /// Base row styles
 ///
-/// @param {String} $experience [null]
 /// @param {String} $grid-mode [$o-grid-mode]
 /// @param {String} $selector [null] - e.g. '.o-grid-row'
-@mixin oGridRow($experience: null, $grid-mode: $o-grid-mode, $selector: null) {
-	// We build a core experience (usually: for browsers that don't cut the mustard)…
-	@if $experience == 'core' {
+@mixin oGridRow($grid-mode: $o-grid-mode, $selector: null) {
+	clear: both;
+	min-width: $o-grid-min-width;
+	// Older browsers get a fixed-width layout
+	max-width: oGridGetMaxWidthForLayout($o-grid-fixed-layout);
+	padding-left: $o-grid-gutter / 2;
+	padding-right: $o-grid-gutter / 2;
+	box-sizing: border-box;
+	margin-left: auto;
+	margin-right: auto;
+
+	// Clearfix
+	zoom: 1;
+
+	&:before,
+	&:after {
+		content: ' ';
+		display: table;
+	}
+	&:after {
 		clear: both;
-		min-width: $o-grid-min-width;
-		// Older browsers get a fixed-width layout
-		max-width: oGridGetMaxWidthForLayout($o-grid-fixed-layout);
-		padding-left: $o-grid-gutter / 2;
-		padding-right: $o-grid-gutter / 2;
-		box-sizing: border-box;
-		margin-left: auto;
-		margin-right: auto;
+	}
 
-		// Clearfix
-		zoom: 1;
+	// Serve a fixed-width layout to IE8
+	@include oGridTargetIE8 {
+		width: oGridGetMaxWidthForLayout($o-grid-fixed-layout);
+	}
 
-		&:before,
-		&:after {
-			content: ' ';
-			display: table;
-		}
-		&:after {
-			clear: both;
-		}
-
-		// Nested rows overrides
-		@if $selector {
-			// Substract outer gutter space from nested rows
-			// and restore fluidity
-			#{unquote($selector)} {
-				width: auto;
-				min-width: 0;
-				max-width: none;
-				margin-left: -$o-grid-gutter / 2;
-				margin-right: -$o-grid-gutter / 2;
-				padding-left: 0;
-				padding-right: 0;
-			}
+	// Nested rows overrides
+	@if $selector {
+		// Substract outer gutter space from nested rows
+		// and restore fluidity
+		#{unquote($selector)} {
+			width: auto;
+			min-width: 0;
+			max-width: none;
+			margin-left: -$o-grid-gutter / 2;
+			margin-right: -$o-grid-gutter / 2;
+			padding-left: 0;
+			padding-right: 0;
 		}
 	}
 
-	// …and then build a better experience on top of it for modern browsers:
-	@if $o-grid-enable-enhanced-experience {
-		@if $experience == 'enhanced' {
+	@if $grid-mode == 'fixed' {
+		// If the grid isn't fluid, we set it to a certain width
+		width: oGridGetMaxWidthForLayout($o-grid-fixed-layout);
+	} @else {
+		max-width: $_o-grid-max-width;
 
-			@if $grid-mode == 'fixed' {
-				// If the grid isn't fluid, we set it to a certain width
-				width: oGridGetMaxWidthForLayout($o-grid-fixed-layout);
-			} @else {
-				max-width: $_o-grid-max-width;
-
-				@if 'global' == $_o-grid-scope {
-					@each $layout-name in $_o-grid-layout-names {
-						@if index($_o-grid-layout-names, $layout-name) >= index($_o-grid-layout-names, $o-grid-start-snappy-mode-at) {
-							@include oGridRespondTo($layout-name) {
-								// If the grid mode is snappy, all rows should be snappy
-								@if $grid-mode == 'snappy' {
-									max-width: map-get($o-grid-layouts, $layout-name);
-								}
-								@if $grid-mode == 'fluid' {
-									// If the grid mode is fluid, then use a class to make a row or a set of rows snappy
-									@at-root .o-grid-snappy {
-										max-width: map-get($o-grid-layouts, $layout-name);
-									}
-								}
+		@if 'global' == $_o-grid-scope {
+			@each $layout-name in $_o-grid-layout-names {
+				@if index($_o-grid-layout-names, $layout-name) >= index($_o-grid-layout-names, $o-grid-start-snappy-mode-at) {
+					@include oGridRespondTo($layout-name) {
+						// If the grid mode is snappy, all rows should be snappy
+						@if $grid-mode == 'snappy' {
+							max-width: map-get($o-grid-layouts, $layout-name);
+						}
+						@if $grid-mode == 'fluid' {
+							// If the grid mode is fluid, then use a class to make a row or a set of rows snappy
+							@at-root .o-grid-snappy {
+								max-width: map-get($o-grid-layouts, $layout-name);
 							}
 						}
 					}
 				}
 			}
-		}
-	}
-
-	@if $experience == null {
-		@include oGridRow($experience: 'core', $grid-mode: $grid-mode, $selector: $selector);
-
-		@include oGridTargetIE8 {
-			@include oGridRow($experience: 'enhanced', $grid-mode: 'fixed', $selector: $selector);
-		}
-		@include oGridTargetModernBrowsers {
-			@include oGridRow($experience: 'enhanced', $grid-mode: $grid-mode, $selector: $selector);
 		}
 	}
 }
@@ -475,90 +441,22 @@
 	}
 }
 
-/// Columns and rows base structure
-///
-/// @param {String} $experience [null]
-@mixin oGridLayout($experience: null, $grid-mode: $o-grid-mode) {
-	@if $experience == 'core' or $experience == null {
-		// Basic layout styles
-		.o-grid-row {
-			@include oGridRow($experience: 'core', $selector: '.o-grid-row');
-		}
-		[data-o-grid-colspan] {
-			@include oGridColumn($experience: 'core');
-		}
-	}
-	@if $o-grid-enable-enhanced-experience {
-		@if $experience == 'enhanced' or $experience == null {
-			.o-grid-row {
-				@include oGridRow($experience: 'enhanced', $grid-mode: $grid-mode);
-			}
-
-			// If the grid is fluid, use this class to enable snappy mode on a set of rows
-			@if $grid-mode == 'fluid' {
-				.o-grid-snappy {
-					margin-left: auto;
-					margin-right: auto;
-				}
-			}
-
-			[data-o-grid-colspan] {
-				@include oGridColumn($experience: 'enhanced');
-
-				// Prevent whitespace between the last column and the right edge of the layout
-				+ [data-o-grid-colspan]:last-child {
-					float: right;
-				}
-			}
-			@for $colspan from 1 through $o-grid-columns {
-				[data-o-grid-colspan~="#{$colspan}"] {
-					width: oGridColspan($colspan, $o-grid-columns);
-				}
-			}
-			// Compact, gutterless row of columns
-			.o-grid-row-compact, // Deprecated, here for retrocompatibility
-			.o-grid-row--compact {
-				&,
-				> [data-o-grid-colspan] {
-					@include oGridRemoveGutters;
-				}
-			}
-
-			// one-half, one-third, three-quarters, center, uncenter…
-			@include _oGridHumanFriendlyKeywords;
-
-			// Gutter helpers:
-			// Remove gutters on a row or a column, across all layouts
-			.o-grid-remove-gutters,
-			.o-grid-remove-gutters--left {
-				@include oGridRemoveGutters('left');
-			}
-			.o-grid-remove-gutters,
-			.o-grid-remove-gutters--right {
-				@include oGridRemoveGutters('right');
-			}
-		}
-	}
-}
-
 /// Remove gutters from a column and re-align its child rows
 ///
 /// @param {String} $side [null] - left, right
 @mixin oGridRemoveGutters($side: null) {
-	@if $o-grid-enable-enhanced-experience {
-		@if $side == null or $side == 'left' {
-			padding-left: 0;
+	@if $side == null or $side == 'left' {
+		padding-left: 0;
 
-			.o-grid-row {
-				margin-left: 0;
-			}
+		.o-grid-row {
+			margin-left: 0;
 		}
-		@if $side == null or $side == 'right' {
-			padding-right: 0;
+	}
+	@if $side == null or $side == 'right' {
+		padding-right: 0;
 
-			.o-grid-row {
-				margin-right: 0;
-			}
+		.o-grid-row {
+			margin-right: 0;
 		}
 	}
 }
@@ -573,33 +471,31 @@
 ///
 /// @param {String} $layout-name - One of $o-grid-layouts
 @mixin _oGridModifiersForLayout($layout-name) {
-	@if $o-grid-enable-enhanced-experience {
-		@include _oGridHumanFriendlyKeywords($layout-name);
+	@include _oGridHumanFriendlyKeywords($layout-name);
 
-		@for $colspan from 1 through $o-grid-columns {
-			[data-o-grid-colspan~="#{$layout-name}#{$colspan}"] {
-				// Restore visibility from `display: none`
-				// if `data-o-grid-colspan` was set to `0` or `hide`
-				display: block;
+	@for $colspan from 1 through $o-grid-columns {
+		[data-o-grid-colspan~="#{$layout-name}#{$colspan}"] {
+			// Restore visibility from `display: none`
+			// if `data-o-grid-colspan` was set to `0` or `hide`
+			display: block;
 
-				// Apply width in %
-				width: oGridColspan($colspan, $o-grid-columns);
-			}
+			// Apply width in %
+			width: oGridColspan($colspan, $o-grid-columns);
 		}
+	}
 
-		// Gutter helpers:
-		// Remove gutters on a row or a column for a given layout
-		// Examples:
-		//  <div class="o-row o-grid-remove-gutters--S"></div>
-		//  <div data-o-grid-colspan="6" class="o-grid-remove-gutters--left--S"></div>
-		.o-grid-remove-gutters--#{$layout-name},
-		.o-grid-remove-gutters--left--#{$layout-name} {
-			@include oGridRemoveGutters('left');
-		}
-		.o-grid-remove-gutters--#{$layout-name},
-		.o-grid-remove-gutters--right--#{$layout-name} {
-			@include oGridRemoveGutters('right');
-		}
+	// Gutter helpers:
+	// Remove gutters on a row or a column for a given layout
+	// Examples:
+	//  <div class="o-row o-grid-remove-gutters--S"></div>
+	//  <div data-o-grid-colspan="6" class="o-grid-remove-gutters--left--S"></div>
+	.o-grid-remove-gutters--#{$layout-name},
+	.o-grid-remove-gutters--left--#{$layout-name} {
+		@include oGridRemoveGutters('left');
+	}
+	.o-grid-remove-gutters--#{$layout-name},
+	.o-grid-remove-gutters--right--#{$layout-name} {
+		@include oGridRemoveGutters('right');
 	}
 }
 
@@ -609,27 +505,59 @@
 /// - IE 8 (fixed layout, with columns)
 /// - modern browsers (fluid layout, with columns)
 @mixin oGridGenerate {
-	@include oGridLayout($experience: 'core');
-
-	// Serve the enhanced layout to both IE 8 and modern browsers
-	@include oGridTargetIE8 {
-		@include oGridLayout($experience: 'enhanced', $grid-mode: 'fixed');
+	// Basic layout styles
+	.o-grid-row {
+		@include oGridRow($o-grid-mode, $selector: '.o-grid-row');
 	}
-	@include oGridTargetModernBrowsers {
-		@include oGridLayout($experience: 'enhanced');
+	[data-o-grid-colspan] {
+		@include oGridColumn;
+
+		// Prevent whitespace between the last column and the right edge of the layout
+		+ [data-o-grid-colspan]:last-child {
+			float: right;
+		}
+	}
+
+	// If the grid is fluid, use this class to enable snappy mode on a set of rows
+	@if $o-grid-mode == 'fluid' {
+		.o-grid-snappy {
+			margin-left: auto;
+			margin-right: auto;
+		}
+	}
+
+	@for $colspan from 1 through $o-grid-columns {
+		[data-o-grid-colspan~="#{$colspan}"] {
+			width: oGridColspan($colspan, $o-grid-columns);
+		}
+	}
+
+	// Compact, gutterless row of columns
+	.o-grid-row-compact, // Deprecated, here for retrocompatibility
+	.o-grid-row--compact {
+		&,
+		> [data-o-grid-colspan] {
+			@include oGridRemoveGutters;
+		}
+	}
+
+	// one-half, one-third, three-quarters, center, uncenter…
+	@include _oGridHumanFriendlyKeywords;
+
+	// Gutter helpers:
+	// Remove gutters on a row or a column, across all layouts
+	.o-grid-remove-gutters,
+	.o-grid-remove-gutters--left {
+		@include oGridRemoveGutters('left');
+	}
+	.o-grid-remove-gutters,
+	.o-grid-remove-gutters--right {
+		@include oGridRemoveGutters('right');
 	}
 
 	// For IE 8, output grid helper classes and data- attributes
 	// for the layout defined in $o-grid-fixed-layout
 	@include oGridTargetIE8 {
-		.o-grid-row {
-			width: oGridGetMaxWidthForLayout($o-grid-fixed-layout);
-
-			.o-grid-row {
-				width: auto;
-			}
-		}
-
 		// Output grid modifiers for layouts up to the fixed layout displayed by IE8
 		$last-layout-index: index($_o-grid-layout-names, $o-grid-fixed-layout);
 		@for $i from 1 through $last-layout-index {

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -142,25 +142,6 @@
 	}
 }
 
-/// Wrapper to output cross-browser code
-///
-/// @example scss
-/// .element {
-///   // Core experience rules (IE <= 7…)
-///
-/// 	@include oGridRules {
-/// 		// Enhanced experience rules
-/// 	}
-/// }
-@mixin oGridRules {
-	@include oGridTargetIE8 {
-		@content;
-	}
-	@include oGridTargetModernBrowsers {
-		@content;
-	}
-}
-
 
 /// Human friendly names for portions and centering:
 ///
@@ -245,7 +226,10 @@
 	@if $experience == null {
 		@include oGridColumn($experience: 'core');
 
-		@include oGridRules {
+		@include oGridTargetIE8 {
+			@include oGridColumn($experience: 'enhanced');
+		}
+		@include oGridTargetModernBrowsers {
 			@include oGridColumn($experience: 'enhanced');
 		}
 	}
@@ -264,7 +248,10 @@
 	} @else {
 		// $span is a number or a keyword, so we're outputting the default width for that column
 		@if type-of($span) == number or type-of($span) == string {
-			@include oGridRules {
+			@include oGridTargetIE8 {
+				width: oGridColspan($span);
+			}
+			@include oGridTargetModernBrowsers {
 				width: oGridColspan($span);
 			}
 		}
@@ -277,7 +264,11 @@
 				@if $layout-span == 'hide' {
 					display: none;
 				} @else {
-					@include oGridRules {
+					@include oGridTargetIE8 {
+						display: block;
+						width: oGridColspan($layout-span);
+					}
+					@include oGridTargetModernBrowsers {
 						display: block;
 						width: oGridColspan($layout-span);
 					}

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -9,15 +9,27 @@
 ///  .my-large-container { width: oGridGetMaxWidthForLayout(L); }
 ///
 /// @param {String} $size - one of $layouts
-@function oGridGetMaxWidthForLayout($layout-name) {
+/// @param {String} $grid-mode [$o-grid-mode]
+@function oGridGetMaxWidthForLayout($layout-name, $grid-mode: $o-grid-mode) {
+	$grid-is-responsive: $grid-mode != 'fixed';
+
 	$index: index($_o-grid-layout-names, $layout-name);
 
+	// Largest layout: return its width directly
 	@if $index == length($_o-grid-layout-names) {
 		@return $_o-grid-max-width;
 	}
 
-	$next-layout: nth($_o-grid-layout-names, $index + 1);
-	@return map-get($o-grid-layouts, $next-layout);
+	// Smaller layouts:
+	@if $grid-is-responsive {
+		// - The grid is responsive (fluid or snappy):
+		//   return the next larger layout width
+		$next-layout: nth($_o-grid-layout-names, $index + 1);
+		@return map-get($o-grid-layouts, $next-layout);
+	} @else {
+		// - The grid is fixed, return the current layout width
+		@return map-get($o-grid-layouts, $layout-name);
+	}
 }
 
 /// % width of an element in the grid
@@ -321,7 +333,7 @@
 
 	// Serve a fixed-width layout to IE8
 	@include oGridTargetIE8 {
-		width: oGridGetMaxWidthForLayout($o-grid-fixed-layout);
+		width: oGridGetMaxWidthForLayout($o-grid-fixed-layout, $grid-mode: 'fixed');
 	}
 
 	// Nested rows overrides
@@ -341,7 +353,7 @@
 
 	@if $grid-mode == 'fixed' {
 		// If the grid isn't fluid, we set it to a certain width
-		width: oGridGetMaxWidthForLayout($o-grid-fixed-layout);
+		width: oGridGetMaxWidthForLayout($o-grid-fixed-layout, $grid-mode: 'fixed');
 	} @else {
 		max-width: $_o-grid-max-width;
 
@@ -560,8 +572,8 @@
 	@include oGridTargetIE8 {
 		// Output grid modifiers for layouts up to the fixed layout displayed by IE8
 		$last-layout-index: index($_o-grid-layout-names, $o-grid-fixed-layout);
-		@for $i from 1 through $last-layout-index {
-			@include _oGridModifiersForLayout(nth($_o-grid-layout-names, $i));
+		@for $index from 1 through $last-layout-index {
+			@include _oGridModifiersForLayout(nth($_o-grid-layout-names, $index));
 		}
 	}
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -34,14 +34,6 @@ $o-grid-fixed-layout: 'L' !default;
 /// @type String
 $o-grid-start-snappy-mode-at: 'M' !default;
 
-/// Turn the enhanced experience on / off
-///
-/// When set to `false`, the core experience will be displayed
-/// (useful for debugging purposes)
-///
-/// @type Bool - set to false to view the core experience only
-$o-grid-enable-enhanced-experience: true !default;
-
 /// Show the currently active breakpoint and output loaded settings
 /// @link https://github.com/sass-mq/sass-mq#seeing-the-currently-active-breakpoint
 ///


### PR DESCRIPTION
The core experience was supposed to be a single column layout, without any floats, which is impractical for development since it forces the use of hacks targeting modern browsers and IE8 only to serve any layout rule.

Since we don't support IE7 and really old browsers anyway (even version 2 of o-grid isn't , I suggest we simplify o-grid.

### Changes

- Remove `@include oGridRules {}` (was used to target both IE8 and modern browsers)
- Remove all references to "core experience" / "enhanced experience"

#### Pros
- Sass is 100 lines of code smaller
- Verbose mode output is 4 KB smaller (~0.1 KB gzipped…)
- Silent mode output is significantly smaller (product-dependant, can't measure directly)

#### Cons
- IE7 wasn't supported in any module anyway, so not sure we're "losing support" for something that's never been supported


### Suggestions to support older browsers
- Like on the BBC News site: layout is broken but content is still consumable
- If the core experience is important for your product and the audience's typology justifies the development cost, use browsers hacks in the product stylesheets