### PR TITLE
Don't always try and recalc whether we're in IE8

### DIFF
--- a/src/js/getCurrentLayout.js
+++ b/src/js/getCurrentLayout.js
@@ -4,7 +4,8 @@
  * Detect IE 8 through injected conditional comments:
  * no UA detection, no need for conditional compilation or JS check
  */
-function isIE8() {
+var isIE8 = (function() {
+
 	var b = document.createElement('B');
 	var docElem = document.documentElement;
 	var isIE;
@@ -14,7 +15,7 @@ function isIE8() {
 	isIE = !!document.getElementById('ie8test');
 	docElem.removeChild(b);
 	return isIE;
-}
+}());
 
 /**
  * Get the currently displayed layout, from $o-grid-layouts in _variables.scss
@@ -22,7 +23,7 @@ function isIE8() {
  * In IE 8, always return the L layout
  */
 module.exports = function() {
-	if (isIE8()) {
+	if (isIE8) {
 		return 'L';
 	}
 


### PR DESCRIPTION
It's very unlikely to change once it's been calculated once, (although it will get calc'd on each 'require').

I noticed this was adding to the scroll jank using chrome 41 in `o-techdocs`, see: https://github.com/Financial-Times/o-techdocs/blob/master/src/js/nav.js#L46.

![screen shot 2015-03-10 at 19 29 08](https://cloud.githubusercontent.com/assets/840334/6583397/c93fe29c-c75b-11e4-88f0-b75901eef522.png)


