### PR TITLE
Revert "fixed getCurrentLayout in ie9"

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -32,7 +32,7 @@
 ///  var getCurrentLayout = require('o-grid/src/js/getCurrentLayout');
 ///  var currentLayout = getCurrentLayout; // One of $o-grid-layouts
 @mixin oGridSurfaceCurrentLayout {
-	body:after {
+	head:after {
 		content: 'default'; // By default, we're exposing the XS layout (from 0 to S)
 		// Hide content visually
 		border: 0;

--- a/src/js/getCurrentLayout.js
+++ b/src/js/getCurrentLayout.js
@@ -26,5 +26,5 @@ module.exports = function() {
 		return 'L';
 	}
 
-	return window.getComputedStyle(document.body, ':after').getPropertyValue('content').replace(/"/g, '').replace(/'/g, '');
+	return window.getComputedStyle(document.querySelector('head'), ':after').getPropertyValue('content').replace(/"/g, '').replace(/'/g, '');
 };


### PR DESCRIPTION
@wheresrhys I couldn't reproduce the issue you mention with IE 9 (see screenshot below).

Using `<head>` avoids polluting `<body>`'s `:after` which could very well be styled in other ways.

Can you have a look at what might be the problem on your end?

![screenshot 2015-03-30 10 27 37](https://cloud.githubusercontent.com/assets/85783/6893753/830ae558-d6c7-11e4-9874-39ca652da550.png)