### PR TITLE
Non-ascii quotes in comment is causing issues with gulp-sass. Fixed.

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -11,7 +11,7 @@
 ///
 /// @type Bool
 ///
-/// @link http://origami.ft.com/docs/syntax/scss/#silent-styles “Silent” styles in Origami's documentation
+/// @link http://origami.ft.com/docs/syntax/scss/#silent-styles "Silent" styles in Origami's documentation
 $o-grid-is-silent: true !default;
 
 /// Grid mode


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/4048999/7742573/618bf0ac-ff99-11e4-8a93-a5a71b59f05d.png)
