### PR TITLE
Clean up demos and make layout changes more obvious

### DIFF
--- a/demos/always-fixed.html
+++ b/demos/always-fixed.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html class="o-hoverable-on demo">
+<html class="o-hoverable-on ">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-grid: always-fixed demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:css-boxsizing,default"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=css-boxsizing,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-grid:/demos/src/scss/always-fixed.scss" />
@@ -57,21 +57,67 @@
 <div class="o-grid-row">
 	<div data-o-grid-colspan="8 S12 M8">
 		<div class="demo-cell">
-			8 S12 M8
+			<span data-demo-highlight="default">8</span>
+			<span data-demo-highlight="S">S12</span>
+			<span data-demo-highlight="M L XL">M8</span>
+
 			<div class="o-grid-row">
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>
 	<div data-o-grid-colspan="4 S12 M4">
 		<div class="demo-cell">
-			4 S12 M4
+			<span data-demo-highlight="default">4</span>
+			<span data-demo-highlight="S">S12</span>
+			<span data-demo-highlight="M L XL">M4</span>
+
 			<div class="o-grid-row">
-				<div data-o-grid-colspan="12 L7 XL6"><div class="demo-cell">12 L7 XL6</div></div>
-				<div data-o-grid-colspan="12 L5 XL6"><div class="demo-cell">12 L5 XL6</div></div>
+				<div data-o-grid-colspan="12 L7 XL6">
+					<div class="demo-cell">
+						<span data-demo-highlight="default S M">12</span>
+						<span data-demo-highlight="L">L7</span>
+						<span data-demo-highlight="XL">XL6</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="12 L5 XL6">
+					<div class="demo-cell">
+						<span data-demo-highlight="default S M">12</span>
+						<span data-demo-highlight="L">L5</span>
+						<span data-demo-highlight="XL">XL6</span>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/demos/always-fixed.html
+++ b/demos/always-fixed.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="o-hoverable-on ">
+<html class="o-hoverable-on demo">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />

--- a/demos/default.html
+++ b/demos/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="o-hoverable-on ">
+<html class="o-hoverable-on demo">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />

--- a/demos/default.html
+++ b/demos/default.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html class="o-hoverable-on demo">
+<html class="o-hoverable-on ">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-grid: default demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:css-boxsizing,default"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=css-boxsizing,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-grid:/demos/src/scss/default.scss" />
@@ -57,21 +57,67 @@
 <div class="o-grid-row">
 	<div data-o-grid-colspan="8 S12 M8">
 		<div class="demo-cell">
-			8 S12 M8
+			<span data-demo-highlight="default">8</span>
+			<span data-demo-highlight="S">S12</span>
+			<span data-demo-highlight="M L XL">M8</span>
+
 			<div class="o-grid-row">
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>
 	<div data-o-grid-colspan="4 S12 M4">
 		<div class="demo-cell">
-			4 S12 M4
+			<span data-demo-highlight="default">4</span>
+			<span data-demo-highlight="S">S12</span>
+			<span data-demo-highlight="M L XL">M4</span>
+
 			<div class="o-grid-row">
-				<div data-o-grid-colspan="12 L7 XL6"><div class="demo-cell">12 L7 XL6</div></div>
-				<div data-o-grid-colspan="12 L5 XL6"><div class="demo-cell">12 L5 XL6</div></div>
+				<div data-o-grid-colspan="12 L7 XL6">
+					<div class="demo-cell">
+						<span data-demo-highlight="default S M">12</span>
+						<span data-demo-highlight="L">L7</span>
+						<span data-demo-highlight="XL">XL6</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="12 L5 XL6">
+					<div class="demo-cell">
+						<span data-demo-highlight="default S M">12</span>
+						<span data-demo-highlight="L">L5</span>
+						<span data-demo-highlight="XL">XL6</span>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/demos/ie8.html
+++ b/demos/ie8.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html class="o-hoverable-on demo">
+<html class="o-hoverable-on ">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-grid: ie8 demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:css-boxsizing,default"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=css-boxsizing,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-grid:/demos/src/scss/ie8.scss" />
@@ -57,21 +57,67 @@
 <div class="o-grid-row">
 	<div data-o-grid-colspan="8 S12 M8">
 		<div class="demo-cell">
-			8 S12 M8
+			<span data-demo-highlight="default">8</span>
+			<span data-demo-highlight="S">S12</span>
+			<span data-demo-highlight="M L XL">M8</span>
+
 			<div class="o-grid-row">
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>
 	<div data-o-grid-colspan="4 S12 M4">
 		<div class="demo-cell">
-			4 S12 M4
+			<span data-demo-highlight="default">4</span>
+			<span data-demo-highlight="S">S12</span>
+			<span data-demo-highlight="M L XL">M4</span>
+
 			<div class="o-grid-row">
-				<div data-o-grid-colspan="12 L7 XL6"><div class="demo-cell">12 L7 XL6</div></div>
-				<div data-o-grid-colspan="12 L5 XL6"><div class="demo-cell">12 L5 XL6</div></div>
+				<div data-o-grid-colspan="12 L7 XL6">
+					<div class="demo-cell">
+						<span data-demo-highlight="default S M">12</span>
+						<span data-demo-highlight="L">L7</span>
+						<span data-demo-highlight="XL">XL6</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="12 L5 XL6">
+					<div class="demo-cell">
+						<span data-demo-highlight="default S M">12</span>
+						<span data-demo-highlight="L">L5</span>
+						<span data-demo-highlight="XL">XL6</span>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/demos/ie8.html
+++ b/demos/ie8.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="o-hoverable-on ">
+<html class="o-hoverable-on demo">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />

--- a/demos/resized.html
+++ b/demos/resized.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html class="o-hoverable-on demo">
+<html class="o-hoverable-on ">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-grid: resized demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:css-boxsizing,default"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=css-boxsizing,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-grid:/demos/src/scss/resized.scss" />
@@ -57,21 +57,67 @@
 <div class="o-grid-row">
 	<div data-o-grid-colspan="8 S12 M8">
 		<div class="demo-cell">
-			8 S12 M8
+			<span data-demo-highlight="default">8</span>
+			<span data-demo-highlight="S">S12</span>
+			<span data-demo-highlight="M L XL">M8</span>
+
 			<div class="o-grid-row">
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>
 	<div data-o-grid-colspan="4 S12 M4">
 		<div class="demo-cell">
-			4 S12 M4
+			<span data-demo-highlight="default">4</span>
+			<span data-demo-highlight="S">S12</span>
+			<span data-demo-highlight="M L XL">M4</span>
+
 			<div class="o-grid-row">
-				<div data-o-grid-colspan="12 L7 XL6"><div class="demo-cell">12 L7 XL6</div></div>
-				<div data-o-grid-colspan="12 L5 XL6"><div class="demo-cell">12 L5 XL6</div></div>
+				<div data-o-grid-colspan="12 L7 XL6">
+					<div class="demo-cell">
+						<span data-demo-highlight="default S M">12</span>
+						<span data-demo-highlight="L">L7</span>
+						<span data-demo-highlight="XL">XL6</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="12 L5 XL6">
+					<div class="demo-cell">
+						<span data-demo-highlight="default S M">12</span>
+						<span data-demo-highlight="L">L5</span>
+						<span data-demo-highlight="XL">XL6</span>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/demos/resized.html
+++ b/demos/resized.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="o-hoverable-on ">
+<html class="o-hoverable-on demo">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />

--- a/demos/snappy.html
+++ b/demos/snappy.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html class="o-hoverable-on demo">
+<html class="o-hoverable-on ">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-grid: snappy demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:css-boxsizing,default"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=css-boxsizing,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-grid:/demos/src/scss/snappy.scss" />
@@ -57,21 +57,67 @@
 <div class="o-grid-row">
 	<div data-o-grid-colspan="8 S12 M8">
 		<div class="demo-cell">
-			8 S12 M8
+			<span data-demo-highlight="default">8</span>
+			<span data-demo-highlight="S">S12</span>
+			<span data-demo-highlight="M L XL">M8</span>
+
 			<div class="o-grid-row">
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>
 	<div data-o-grid-colspan="4 S12 M4">
 		<div class="demo-cell">
-			4 S12 M4
+			<span data-demo-highlight="default">4</span>
+			<span data-demo-highlight="S">S12</span>
+			<span data-demo-highlight="M L XL">M4</span>
+
 			<div class="o-grid-row">
-				<div data-o-grid-colspan="12 L7 XL6"><div class="demo-cell">12 L7 XL6</div></div>
-				<div data-o-grid-colspan="12 L5 XL6"><div class="demo-cell">12 L5 XL6</div></div>
+				<div data-o-grid-colspan="12 L7 XL6">
+					<div class="demo-cell">
+						<span data-demo-highlight="default S M">12</span>
+						<span data-demo-highlight="L">L7</span>
+						<span data-demo-highlight="XL">XL6</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="12 L5 XL6">
+					<div class="demo-cell">
+						<span data-demo-highlight="default S M">12</span>
+						<span data-demo-highlight="L">L5</span>
+						<span data-demo-highlight="XL">XL6</span>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/demos/snappy.html
+++ b/demos/snappy.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="o-hoverable-on ">
+<html class="o-hoverable-on demo">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />

--- a/demos/src/config.js
+++ b/demos/src/config.js
@@ -8,7 +8,7 @@ Object.keys(configurations).forEach(function(key) {
 		description: configurations[key],
 		sass: 'demos/src/scss/' + key + '.scss',
 		template: 'demos/src/layout.mustache',
-		bodyClasses: 'demo',
+		htmlClasses: 'demo',
 		expanded: (key === 'default')
 	});
 });
@@ -20,8 +20,9 @@ demos.push({
 	template: 'demos/src/test.mustache',
 	data: 'demos/src/configurations.json',
 	js: 'demos/src/js/style-switcher.js',
-	bodyClasses: 'test',
-	expanded: false
+	htmlClasses: 'test',
+	expanded: false,
+	dependencies: ["o-buttons@^2.0.0"]
 });
 
 module.exports = {

--- a/demos/src/config.js
+++ b/demos/src/config.js
@@ -8,7 +8,7 @@ Object.keys(configurations).forEach(function(key) {
 		description: configurations[key],
 		sass: 'demos/src/scss/' + key + '.scss',
 		template: 'demos/src/layout.mustache',
-		htmlClasses: 'demo',
+		documentClasses: 'demo',
 		expanded: (key === 'default')
 	});
 });
@@ -20,7 +20,7 @@ demos.push({
 	template: 'demos/src/test.mustache',
 	data: 'demos/src/configurations.json',
 	js: 'demos/src/js/style-switcher.js',
-	htmlClasses: 'test',
+	documentClasses: 'test',
 	expanded: false,
 	dependencies: ["o-buttons@^2.0.0"]
 });

--- a/demos/src/js/style-switcher.js
+++ b/demos/src/js/style-switcher.js
@@ -49,24 +49,25 @@ if (![].includes) {
 // Self-contained stylesheet switcher
 (function styleSwitcher() {
 	var demoTypes = require('../configurations.json');
-	var stylesheet = document.querySelector("link[rel='stylesheet']");
+	var stylesheet = document.querySelector("link[href*='default']");
 	var html = document.documentElement;
-	var buttonContainer = document.getElementById("styleSwitcher");
+	var buttonContainer = document.getElementById("js-demo-switcher");
 	var tmp = document.createDocumentFragment();
 	var subheading = document.getElementById("subheading");
 
 	Object.keys(demoTypes).forEach(function (type) {
 		var button  = document.createElement('button');
+		button.classList.add('o-buttons');
 		var stylePath = local ? type + '.css' : 'scss/' + type + '.scss';
 		button.innerHTML = type;
 		button.title = demoTypes[type];
 		button.addEventListener('click', function () {
 			stylesheet.href = stylePath;
-			var prev = document.querySelector('.selected-stylesheet');
+			var prev = document.querySelector('[aria-selected=true]');
 			if (prev) {
-				prev.className = '';
+				prev.setAttribute('aria-selected', 'false');
 			}
-			this.className = 'selected-stylesheet';
+			this.setAttribute('aria-selected', 'true');
 
 			subheading && (subheading.innerHTML = this.title);
 			html.className = html.className.replace(/\sstylesheet-(\w|-)+/, '') + ' stylesheet-' + type;
@@ -75,7 +76,7 @@ if (![].includes) {
 		});
 		if (!tmp.childNodes.length) {
 			stylesheet.href = stylePath;
-			button.className = 'selected-stylesheet';
+			button.setAttribute('aria-selected', 'true');
 			html.className += ' stylesheet-' + type;
 			subheading && (subheading.innerHTML = button.title);
 		}

--- a/demos/src/js/style-switcher.js
+++ b/demos/src/js/style-switcher.js
@@ -312,6 +312,6 @@ function runTests() {
 	};
 }
 
-if (document.body.classList.contains('test')) {
+if (document.documentElement.classList.contains('test')) {
 	runTests();
 }

--- a/demos/src/layout.mustache
+++ b/demos/src/layout.mustache
@@ -44,21 +44,67 @@
 <div class="o-grid-row">
 	<div data-o-grid-colspan="8 S12 M8">
 		<div class="demo-cell">
-			8 S12 M8
+			<span data-demo-highlight="default">8</span>
+			<span data-demo-highlight="S">S12</span>
+			<span data-demo-highlight="M L XL">M8</span>
+
 			<div class="o-grid-row">
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
-				<div data-o-grid-colspan="6 XL3 S12 M6"><div class="demo-cell">6 XL3 S12 M6</div></div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="6 S12 M6 XL3">
+					<div class="demo-cell">
+						<span data-demo-highlight="default">6</span>
+						<span data-demo-highlight="S">S12</span>
+						<span data-demo-highlight="M L">M6</span>
+						<span data-demo-highlight="XL">XL3</span>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>
 	<div data-o-grid-colspan="4 S12 M4">
 		<div class="demo-cell">
-			4 S12 M4
+			<span data-demo-highlight="default">4</span>
+			<span data-demo-highlight="S">S12</span>
+			<span data-demo-highlight="M L XL">M4</span>
+
 			<div class="o-grid-row">
-				<div data-o-grid-colspan="12 L7 XL6"><div class="demo-cell">12 L7 XL6</div></div>
-				<div data-o-grid-colspan="12 L5 XL6"><div class="demo-cell">12 L5 XL6</div></div>
+				<div data-o-grid-colspan="12 L7 XL6">
+					<div class="demo-cell">
+						<span data-demo-highlight="default S M">12</span>
+						<span data-demo-highlight="L">L7</span>
+						<span data-demo-highlight="XL">XL6</span>
+					</div>
+				</div>
+				<div data-o-grid-colspan="12 L5 XL6">
+					<div class="demo-cell">
+						<span data-demo-highlight="default S M">12</span>
+						<span data-demo-highlight="L">L5</span>
+						<span data-demo-highlight="XL">XL6</span>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/demos/src/scss/_demos.scss
+++ b/demos/src/scss/_demos.scss
@@ -12,7 +12,7 @@ body {
 }
 
 // Display configuration information
-.test:after {
+.test body:after {
 	content: '';
 	background-color: #fcf8e3;
 	border-bottom: 1px solid #fbeed5;

--- a/demos/src/scss/_demos.scss
+++ b/demos/src/scss/_demos.scss
@@ -1,5 +1,6 @@
 body {
 	font-family: Arial, Helvetica, sans-serif;
+	color: #505050;
 }
 body {
 	overflow-x: hidden;
@@ -28,10 +29,12 @@ h2 {
 .demo-cell {
 	background-color: transparent;
 	zoom: 1;
-	min-height: 30px;
+	min-height: 2em;
 	text-align: center;
-	padding-top: 10px;
+	padding-top: 1rem;
 	overflow: hidden;
+	font-size: 1.3rem;
+	line-height: 1.2;
 
 	// Transparent background color in IE8
 	$rgba: rgba(#ffffff, 0.5);
@@ -42,19 +45,20 @@ h2 {
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#{$ie-hex-str},endColorstr=#{$ie-hex-str});
 }
 .o-grid-row {
-	background: #bdcaff;
-	margin-top: 10px;
-	margin-bottom: 10px;
+	background: #f6e9d8;
+	margin-top: 1rem;
+	margin-bottom: 1rem;
 
 	.o-grid-row {
-		background: #dc73ff;
+		background: #cec6b9;
 	}
 }
 
 [class*='error'] .demo-cell {
-	background-color: red;
+	background-color: #c00d00;
 }
 
-.selected-stylesheet {
-	background: #aaaaff;
+.demo-switcher {
+	margin: 1rem 0;
+	text-align: center;
 }

--- a/demos/src/scss/_demos.scss
+++ b/demos/src/scss/_demos.scss
@@ -1,9 +1,14 @@
-body {
-	font-family: Arial, Helvetica, sans-serif;
-	color: #505050;
+html {
+	/* Set a font family on the whole document */
+	font-family: BentonSans, sans-serif;
+
+	/* Prevent navigation menus from creating
+	   extra space on sides of the page */
+	overflow-x: hidden;
 }
 body {
-	overflow-x: hidden;
+	/* Remove space around the document */
+	margin: 0;
 }
 
 // Display configuration information

--- a/demos/src/scss/default.scss
+++ b/demos/src/scss/default.scss
@@ -1,1 +1,31 @@
 @import "common";
+
+[data-demo-highlight] {
+	display: inline-block;
+	transition: 0.2s all 0.25s ease-in-out;
+	opacity: 0.6;
+	transform: scale(0.75);
+}
+
+@mixin demo-highlight($from: false, $until: false) {
+	@include oGridRespondTo($from: $from, $until: $until) {
+		transform: scale(1);
+		opacity: 1;
+	}
+}
+[data-demo-highlight*="default"] {
+	@include demo-highlight($until: S);
+}
+[data-demo-highlight*="S"] {
+	@include demo-highlight(S, M);
+}
+[data-demo-highlight*="M"] {
+	@include demo-highlight(M, L);
+}
+[data-demo-highlight="L"],
+[data-demo-highlight*=" L"] {
+	@include demo-highlight(L, XL);
+}
+[data-demo-highlight*="XL"] {
+	@include demo-highlight(XL);
+}

--- a/demos/src/test.mustache
+++ b/demos/src/test.mustache
@@ -1,4 +1,5 @@
-<div id="styleSwitcher"></div>
+
+<div id="js-demo-switcher" class="o-buttons__group demo-switcher"></div>
 
 <h2>Default unresponsive columns</h2>
 

--- a/demos/test.html
+++ b/demos/test.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
-<html class="o-hoverable-on test">
+<html class="o-hoverable-on ">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-grid: test demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:css-boxsizing,default"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=css-boxsizing,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
-	<link rel="stylesheet" href="/bundles/css?modules=o-grid:/demos/src/scss/default.scss" />
+	<link rel="stylesheet" href="/bundles/css?modules=o-grid:/demos/src/scss/default.scss,o-buttons@^2.0.0" />
 </head>
 <body>
-<div id="styleSwitcher"></div>
+
+<div id="js-demo-switcher" class="o-buttons__group demo-switcher"></div>
 
 <h2>Default unresponsive columns</h2>
 
@@ -245,7 +246,7 @@
 
 <script src="//code.jquery.com/jquery-1.11.1.min.js"></script>
 
-<script src="/bundles/js?modules=o-grid:/demos/src/js/style-switcher.js"></script>
+<script src="/bundles/js?modules=o-grid:/demos/src/js/style-switcher.js,o-buttons@^2.0.0"></script>
 <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/demos/test.html
+++ b/demos/test.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="o-hoverable-on ">
+<html class="o-hoverable-on test">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />


### PR DESCRIPTION
PR to merge into #89.

- Adds animations to explain what is happening between layouts directly in the demos.
- Uses FT colours
- Improves usability of tests (using o-buttons)

### Animations between layouts
![grid-animation](https://cloud.githubusercontent.com/assets/85783/8483409/97921a08-20e8-11e5-9d23-a061d803b0cd.gif)

### Test button group
![screenshot 2015-07-02 18 27 21](https://cloud.githubusercontent.com/assets/85783/8483328/00f038e6-20e8-11e5-9950-c46b51dd96bf.png)
