### PR TITLE
Use flexbox for laying out columns

### DIFF
--- a/demos/src/scss/_demos.scss
+++ b/demos/src/scss/_demos.scss
@@ -31,7 +31,12 @@ h2 {
 	@include oGridRow;
 }
 
+[data-o-grid-colspan] {
+	display: flex;
+}
+
 .demo-cell {
+	flex-grow: 1;
 	background-color: transparent;
 	zoom: 1;
 	min-height: 2em;

--- a/demos/src/scss/_demos.scss
+++ b/demos/src/scss/_demos.scss
@@ -31,12 +31,7 @@ h2 {
 	@include oGridRow;
 }
 
-[data-o-grid-colspan] {
-	display: flex;
-}
-
 .demo-cell {
-	flex-grow: 1;
 	background-color: transparent;
 	zoom: 1;
 	min-height: 2em;
@@ -61,6 +56,19 @@ h2 {
 
 	.o-grid-row {
 		background: #cec6b9;
+	}
+}
+
+// Showcase flexbox interactions
+// Note that this breaks cases such as:
+// <div data-o-grid-colspan="0">
+// <div data-o-grid-colspan="Lhide">
+// Because these rely on "display: none" to hide columns
+.demo-flex {
+	display: flex;
+
+	.demo-cell {
+		flex: 1 1 0%;
 	}
 }
 

--- a/demos/src/test.mustache
+++ b/demos/src/test.mustache
@@ -122,6 +122,34 @@
 	<div data-o-grid-colspan="12 S3 M4 L4 XL4"><div class="demo-cell">12 S3 M4 L4 XL4</div></div>
 </div>
 
+<h2>Flexbox interaction</h2>
+
+<div class="o-grid-row">
+	<div class="demo-flex" data-o-grid-colspan="12 S12 M12 L4 XL4">
+		<div class="demo-cell">
+			12 S12 M12 L4 XL4<br/>and a lots and lots and lots and lots of extra text to make the columns different heights
+			</div>
+		</div>
+	<div class="demo-flex" data-o-grid-colspan="12 S12 M12 L8 XL8"><div class="demo-cell">12 S12 M12 L8 XL8</div></div>
+</div>
+<div class="o-grid-row">
+	<div class="demo-flex" data-o-grid-colspan="12 S12 M12 L4 XL4"><div class="demo-cell">12 S12 M12 L4 XL4</div></div>
+	<div class="demo-flex" data-o-grid-colspan="12 S12 M12 L4 XL4">
+		<div class="demo-cell">
+			12 S12 M12 L4 XL4<br/>and a lots and lots and lots and lots of extra text to make the columns different heights
+		</div>
+	</div>
+	<div class="demo-flex" data-o-grid-colspan="12 S12 M12 L4 XL4"><div class="demo-cell">12 S12 M12 L4 XL4</div></div>
+</div>
+<div class="o-grid-row">
+	<div class="demo-flex" data-o-grid-colspan="12 S12 M12 L8 XL8"><div class="demo-cell">12 S12 M12 L8 XL8</div></div>
+	<div class="demo-flex" data-o-grid-colspan="12 S12 M12 L4 XL4">
+		<div class="demo-cell">
+			12 S12 M12 L4 XL4<br/>and a lots and lots and lots and lots of extra text to make the columns different heights
+		</div>
+	</div>
+</div>
+
 <h2>Nested grids</h2>
 
 <div class="o-grid-row">

--- a/demos/test.html
+++ b/demos/test.html
@@ -135,6 +135,34 @@
 	<div data-o-grid-colspan="12 S3 M4 L4 XL4"><div class="demo-cell">12 S3 M4 L4 XL4</div></div>
 </div>
 
+<h2>Flexbox interaction</h2>
+
+<div class="o-grid-row">
+	<div class="demo-flex" data-o-grid-colspan="12 S12 M12 L4 XL4">
+		<div class="demo-cell">
+			12 S12 M12 L4 XL4<br/>and a lots and lots and lots and lots of extra text to make the columns different heights
+			</div>
+		</div>
+	<div class="demo-flex" data-o-grid-colspan="12 S12 M12 L8 XL8"><div class="demo-cell">12 S12 M12 L8 XL8</div></div>
+</div>
+<div class="o-grid-row">
+	<div class="demo-flex" data-o-grid-colspan="12 S12 M12 L4 XL4"><div class="demo-cell">12 S12 M12 L4 XL4</div></div>
+	<div class="demo-flex" data-o-grid-colspan="12 S12 M12 L4 XL4">
+		<div class="demo-cell">
+			12 S12 M12 L4 XL4<br/>and a lots and lots and lots and lots of extra text to make the columns different heights
+		</div>
+	</div>
+	<div class="demo-flex" data-o-grid-colspan="12 S12 M12 L4 XL4"><div class="demo-cell">12 S12 M12 L4 XL4</div></div>
+</div>
+<div class="o-grid-row">
+	<div class="demo-flex" data-o-grid-colspan="12 S12 M12 L8 XL8"><div class="demo-cell">12 S12 M12 L8 XL8</div></div>
+	<div class="demo-flex" data-o-grid-colspan="12 S12 M12 L4 XL4">
+		<div class="demo-cell">
+			12 S12 M12 L4 XL4<br/>and a lots and lots and lots and lots of extra text to make the columns different heights
+		</div>
+	</div>
+</div>
+
 <h2>Nested grids</h2>
 
 <div class="o-grid-row">

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -227,7 +227,13 @@
 			// Restore visibility from `display: none`
 			// if `data-o-grid-colspan` was set to `0` or `hide`
 			display: block;
+			min-width: oGridColspan($human-friendly-name);
+			max-width: oGridColspan($human-friendly-name);
 			width: oGridColspan($human-friendly-name);
+
+			@include oGridTargetIE8 {
+				min-width: 0;
+			}
 		}
 	}
 }
@@ -269,6 +275,7 @@
 	padding-right: $o-grid-gutter / 2;
 	float: left;
 	box-sizing: border-box;
+	flex: 1 1 0%;
 
 	@if $span {
 		@include oGridColspan($span);
@@ -290,12 +297,7 @@
 	} @else {
 		// $span is a number or a keyword, so we're outputting the default width for that column
 		@if type-of($span) == number or type-of($span) == string {
-			@include oGridTargetIE8 {
-				width: oGridColspan($span);
-			}
-			@include oGridTargetModernBrowsers {
-				width: oGridColspan($span);
-			}
+			width: oGridColspan($span);
 		}
 	}
 
@@ -306,13 +308,13 @@
 				@if $layout-span == 'hide' {
 					display: none;
 				} @else {
+					display: block;
+					min-width: oGridColspan($layout-span);
+					max-width: oGridColspan($layout-span);
+					width: oGridColspan($layout-span);
+
 					@include oGridTargetIE8 {
-						display: block;
-						width: oGridColspan($layout-span);
-					}
-					@include oGridTargetModernBrowsers {
-						display: block;
-						width: oGridColspan($layout-span);
+						min-width: 0;
 					}
 				}
 			} @else {
@@ -336,7 +338,6 @@
 					}
 					@include oGridRespondTo($layout-name) {
 						display: block;
-						width: oGridColspan($layout-span);
 					}
 				}
 			}
@@ -365,14 +366,18 @@
 	box-sizing: border-box;
 	margin-left: auto;
 	margin-right: auto;
+	display: flex;
+	flex-wrap: wrap; // Note that this breaks in old Firefox
 
-	// Clearfix
+	// Clearfix for IE9 and below
 	zoom: 1;
 
 	&:before,
 	&:after {
+		// scss-lint:disable DuplicateProperty
 		content: ' ';
-		display: table;
+		display: none;
+		display: table\9; // Show only to IE<=9
 	}
 	&:after {
 		clear: both;
@@ -549,7 +554,13 @@
 			display: block;
 
 			// Apply width in %
-			width: oGridColspan($colspan, $o-grid-columns);
+			min-width: oGridColspan($colspan);
+			max-width: oGridColspan($colspan);
+			width: oGridColspan($colspan);
+
+			@include oGridTargetIE8 {
+				min-width: 0;
+			}
 		}
 	}
 
@@ -592,7 +603,13 @@
 
 	@for $colspan from 1 through $o-grid-columns {
 		[data-o-grid-colspan~="#{$colspan}"] {
+			min-width: oGridColspan($colspan, $o-grid-columns);
+			max-width: oGridColspan($colspan, $o-grid-columns);
 			width: oGridColspan($colspan, $o-grid-columns);
+
+			@include oGridTargetIE8 {
+				min-width: 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
### Pros

- Allows equal-height columns
- Vertical centering is made easy in modern browsers
- Still works in IE 8 and 9, using the fallback
- According to Paul Lewis, a flexbox grid should be faster to paint than using floats in modern browsers

### Cons

- Browsers that don't support flex-wrap may have layout issues in some edge cases. That said, my tests in IE10 worked perfectly well.

Thanks to @raphaelgoetter for his help.