### PR TITLE
Flexible gutters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A 12 column responsive grid system for laying out documents, templates and modules.
 
-> Living off the grid and being kind of an outlaw brings a dangerous reality.  
+> Living off the grid and being kind of an outlaw brings a dangerous reality.
   *Ron Perlman*
 
 [![Grid system](https://rawgit.com/Financial-Times/o-grid/master/img/grid-system.png)](https://rawgit.com/Financial-Times/o-grid/master/img/grid-system.png)
@@ -49,17 +49,18 @@ Older browsers: you may use a [box-sizing polyfill](https://github.com/Schepp/bo
 ### General settings
 
 * Minimum width: 240px
-* Maximum width: 1210px
-* Gutter width: 10px
+* Maximum width: 1200px
+* Column width: 90px at 1200px (flexible)
+* Gutter width: 10px at 1200px (flexible)
 * Number of columns: 12
 
 ### Layout sizes
 
 * **Default (no layout name)** 240px - …
-* **Small (S)** 490px - 729px
-* **Medium (M)** 730px - 969px
-* **Large (L)** 970px to 1209px
-* **Extra large (XL)** 1210px
+* **Small (S)** 480px - 719px
+* **Medium (M)** 720px - 959px
+* **Large (L)** 960px to 1199px
+* **Extra large (XL)** 1200px
 
 ## Quick start
 
@@ -198,7 +199,7 @@ div { @include oGridColumn((default: hide, L: 12, XL: hide)); }
 
 ```html
 <div data-o-grid-colspan="center Luncenter"></div>
-``` 
+```
 
 ```scss
 .my-column {

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A 12 column responsive grid system for laying out documents, templates and modules.
 
-> Living off the grid and being kind of an outlaw brings a dangerous reality.
-  *Ron Perlman*
+> Living off the grid and being kind of an outlaw brings a dangerous reality.  *Ron Perlman*
 
 [![Grid system](https://rawgit.com/Financial-Times/o-grid/master/img/grid-system.png)](https://rawgit.com/Financial-Times/o-grid/master/img/grid-system.png)
 

--- a/demos/src/js/style-switcher.js
+++ b/demos/src/js/style-switcher.js
@@ -119,7 +119,7 @@ function getExpectedSpans(el) {
 	var layouts = ['XL', 'L', 'M', 'S'];
 	var allLayouts = [];
 
-	var idx = layouts.indexOf(getCurrentLayout())
+	var idx = layouts.indexOf(getCurrentLayout());
 	if(idx > -1) {
 		allLayouts = layouts.slice(idx);
 	}

--- a/demos/src/scss/_demos.scss
+++ b/demos/src/scss/_demos.scss
@@ -30,7 +30,7 @@ body {
 h2 {
 	@include oGridRow;
 	margin-top: 1rem;
-	margin-bottom: 1rem
+	margin-bottom: 1rem;
 }
 
 .demo-cell {

--- a/demos/src/scss/_demos.scss
+++ b/demos/src/scss/_demos.scss
@@ -67,3 +67,25 @@ h2 {
 	margin: 1rem 0;
 	text-align: center;
 }
+
+@include oGridRespondTo(L) {
+	.o-grid-row.flex {
+		display: flex;
+
+		// HACK Mozilla, unlike WebKit follows the flexbox standard to the letter
+		// which means relative margins and paddings on flexboxes are based on element
+		// height and not width. Since the width isn't set, that ends up being 0
+		@-moz-document url-prefix() {
+			padding-top: percentage($o-grid-gutter / 2);
+			padding-bottom: percentage($o-grid-gutter / 2);
+		}
+
+		[data-o-grid-colspan] {
+			display: flex;
+
+			.demo-cell {
+				width: 100%;
+			}
+		}
+	}
+}

--- a/demos/src/scss/_demos.scss
+++ b/demos/src/scss/_demos.scss
@@ -29,6 +29,8 @@ body {
 
 h2 {
 	@include oGridRow;
+	margin-top: 1rem;
+	margin-bottom: 1rem
 }
 
 .demo-cell {
@@ -51,8 +53,6 @@ h2 {
 }
 .o-grid-row {
 	background: #f6e9d8;
-	margin-top: 1rem;
-	margin-bottom: 1rem;
 
 	.o-grid-row {
 		background: #cec6b9;

--- a/demos/src/scss/resized.scss
+++ b/demos/src/scss/resized.scss
@@ -5,7 +5,8 @@ $o-grid-layouts: (
 	'XL': 1200px,
 );
 
-$o-grid-gutter: 5 / 1200;
+$o-grid-column: 80 / 1200;
+$o-grid-gutter: 20 / 1200;
 
 @import 'common';
 

--- a/demos/src/scss/resized.scss
+++ b/demos/src/scss/resized.scss
@@ -1,10 +1,11 @@
 $o-grid-layouts: (
 	'S': 400px,
 	'M': 800px,
-	'L': 1000px
+	'L': 1000px,
+	'XL': 1200px,
 );
 
-$o-grid-gutter: 5px;
+$o-grid-gutter: 5 / 1200;
 
 @import 'common';
 

--- a/demos/src/test.mustache
+++ b/demos/src/test.mustache
@@ -107,6 +107,18 @@
 	<div data-o-grid-colspan="12 S12 M11 L10 XL9"><div class="demo-cell">12 S12 M11 L10 XL9</div></div>
 </div>
 
+<h2>Stacking behaviour</h2>
+
+<div class="o-grid-row">
+	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 M12 L6</div></div>
+	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 M12 L6</div></div>
+</div>
+<div class="o-grid-row">
+	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 M12 L6 XL4</div></div>
+	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 M12 L6 XL4</div></div>
+	<div data-o-grid-colspan="0 S12 M12 L4"><div class="demo-cell">0 M12 L12 XL4</div></div>
+</div>
+
 <h2>Overriding of default width</h2>
 
 <div class="o-grid-row">

--- a/demos/src/test.mustache
+++ b/demos/src/test.mustache
@@ -110,13 +110,13 @@
 <h2>Stacking behaviour</h2>
 
 <div class="o-grid-row">
-	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 M12 L6</div></div>
-	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 M12 L6</div></div>
+	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 S12 M6</div></div>
+	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 S12 M6</div></div>
 </div>
 <div class="o-grid-row">
-	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 M12 L6 XL4</div></div>
-	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 M12 L6 XL4</div></div>
-	<div data-o-grid-colspan="0 S12 M12 L4"><div class="demo-cell">0 M12 L12 XL4</div></div>
+	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 S12 M6 L4</div></div>
+	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 S12 M6 L4</div></div>
+	<div data-o-grid-colspan="0 S12 M12 L4"><div class="demo-cell">0 S12 M12 L4</div></div>
 </div>
 
 <h2>Overriding of default width</h2>

--- a/demos/src/test.mustache
+++ b/demos/src/test.mustache
@@ -107,18 +107,6 @@
 	<div data-o-grid-colspan="12 S12 M11 L10 XL9"><div class="demo-cell">12 S12 M11 L10 XL9</div></div>
 </div>
 
-<h2>Stacking behaviour</h2>
-
-<div class="o-grid-row">
-	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 S12 M6</div></div>
-	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 S12 M6</div></div>
-</div>
-<div class="o-grid-row">
-	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 S12 M6 L4</div></div>
-	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 S12 M6 L4</div></div>
-	<div data-o-grid-colspan="0 S12 M12 L4"><div class="demo-cell">0 S12 M12 L4</div></div>
-</div>
-
 <h2>Overriding of default width</h2>
 
 <div class="o-grid-row">
@@ -132,6 +120,50 @@
 </div>
 <div class="o-grid-row">
 	<div data-o-grid-colspan="12 S3 M4 L4 XL4"><div class="demo-cell">12 S3 M4 L4 XL4</div></div>
+</div>
+
+<h2>Stacking behaviour</h2>
+
+<div class="o-grid-row">
+	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 S12 M6</div></div>
+	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 S12 M6</div></div>
+</div>
+<div class="o-grid-row">
+	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 S12 M6 L4</div></div>
+	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 S12 M6 L4</div></div>
+	<div data-o-grid-colspan="0 S12 M12 L4"><div class="demo-cell">0 S12 M12 L4</div></div>
+</div>
+<div class="o-grid-row">
+	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 S12 M6</div></div>
+	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 S12 M6</div></div>
+</div>
+
+<h2>Flexbox interaction</h2>
+
+<div class="o-grid-row flex">
+	<div data-o-grid-colspan="12 L4">
+		<div class="demo-cell">
+			4<br/>and a lots and lots and lots and lots of extra text to make the columns different heights
+			</div>
+		</div>
+	<div data-o-grid-colspan="12 L8"><div class="demo-cell">8</div></div>
+</div>
+<div class="o-grid-row flex">
+	<div data-o-grid-colspan="12 L4"><div class="demo-cell">4</div></div>
+	<div data-o-grid-colspan="12 L4">
+		<div class="demo-cell">
+			4<br/>and a lots and lots and lots and lots of extra text to make the columns different heights
+		</div>
+	</div>
+	<div data-o-grid-colspan="12 L4"><div class="demo-cell">4</div></div>
+</div>
+<div class="o-grid-row flex">
+	<div data-o-grid-colspan="12 L8"><div class="demo-cell">8</div></div>
+	<div data-o-grid-colspan="12 L4">
+		<div class="demo-cell">
+			4<br/>and a lots and lots and lots and lots of extra text to make the columns different heights
+		</div>
+	</div>
 </div>
 
 <h2>Nested grids</h2>

--- a/demos/test.html
+++ b/demos/test.html
@@ -123,13 +123,13 @@
 <h2>Stacking behaviour</h2>
 
 <div class="o-grid-row">
-	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 M12 L6</div></div>
-	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 M12 L6</div></div>
+	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 S12 M6</div></div>
+	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 S12 M6</div></div>
 </div>
 <div class="o-grid-row">
-	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 M12 L6 XL4</div></div>
-	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 M12 L6 XL4</div></div>
-	<div data-o-grid-colspan="0 S12 M12 L4"><div class="demo-cell">0 M12 L12 XL4</div></div>
+	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 S12 M6 L4</div></div>
+	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 S12 M6 L4</div></div>
+	<div data-o-grid-colspan="0 S12 M12 L4"><div class="demo-cell">0 S12 M12 L4</div></div>
 </div>
 
 <h2>Overriding of default width</h2>

--- a/demos/test.html
+++ b/demos/test.html
@@ -120,18 +120,6 @@
 	<div data-o-grid-colspan="12 S12 M11 L10 XL9"><div class="demo-cell">12 S12 M11 L10 XL9</div></div>
 </div>
 
-<h2>Stacking behaviour</h2>
-
-<div class="o-grid-row">
-	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 S12 M6</div></div>
-	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 S12 M6</div></div>
-</div>
-<div class="o-grid-row">
-	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 S12 M6 L4</div></div>
-	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 S12 M6 L4</div></div>
-	<div data-o-grid-colspan="0 S12 M12 L4"><div class="demo-cell">0 S12 M12 L4</div></div>
-</div>
-
 <h2>Overriding of default width</h2>
 
 <div class="o-grid-row">
@@ -145,6 +133,50 @@
 </div>
 <div class="o-grid-row">
 	<div data-o-grid-colspan="12 S3 M4 L4 XL4"><div class="demo-cell">12 S3 M4 L4 XL4</div></div>
+</div>
+
+<h2>Stacking behaviour</h2>
+
+<div class="o-grid-row">
+	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 S12 M6</div></div>
+	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 S12 M6</div></div>
+</div>
+<div class="o-grid-row">
+	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 S12 M6 L4</div></div>
+	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 S12 M6 L4</div></div>
+	<div data-o-grid-colspan="0 S12 M12 L4"><div class="demo-cell">0 S12 M12 L4</div></div>
+</div>
+<div class="o-grid-row">
+	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 S12 M6</div></div>
+	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 S12 M6</div></div>
+</div>
+
+<h2>Flexbox interaction</h2>
+
+<div class="o-grid-row flex">
+	<div data-o-grid-colspan="12 L4">
+		<div class="demo-cell">
+			4<br/>and a lots and lots and lots and lots of extra text to make the columns different heights
+			</div>
+		</div>
+	<div data-o-grid-colspan="12 L8"><div class="demo-cell">8</div></div>
+</div>
+<div class="o-grid-row flex">
+	<div data-o-grid-colspan="12 L4"><div class="demo-cell">4</div></div>
+	<div data-o-grid-colspan="12 L4">
+		<div class="demo-cell">
+			4<br/>and a lots and lots and lots and lots of extra text to make the columns different heights
+		</div>
+	</div>
+	<div data-o-grid-colspan="12 L4"><div class="demo-cell">4</div></div>
+</div>
+<div class="o-grid-row flex">
+	<div data-o-grid-colspan="12 L8"><div class="demo-cell">8</div></div>
+	<div data-o-grid-colspan="12 L4">
+		<div class="demo-cell">
+			4<br/>and a lots and lots and lots and lots of extra text to make the columns different heights
+		</div>
+	</div>
 </div>
 
 <h2>Nested grids</h2>

--- a/demos/test.html
+++ b/demos/test.html
@@ -120,6 +120,18 @@
 	<div data-o-grid-colspan="12 S12 M11 L10 XL9"><div class="demo-cell">12 S12 M11 L10 XL9</div></div>
 </div>
 
+<h2>Stacking behaviour</h2>
+
+<div class="o-grid-row">
+	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 M12 L6</div></div>
+	<div data-o-grid-colspan="0 S12 M6"><div class="demo-cell">0 M12 L6</div></div>
+</div>
+<div class="o-grid-row">
+	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 M12 L6 XL4</div></div>
+	<div data-o-grid-colspan="0 S12 M6 L4"><div class="demo-cell">0 M12 L6 XL4</div></div>
+	<div data-o-grid-colspan="0 S12 M12 L4"><div class="demo-cell">0 M12 L12 XL4</div></div>
+</div>
+
 <h2>Overriding of default width</h2>
 
 <div class="o-grid-row">

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -394,16 +394,15 @@
 
 	// Clearfix
 	zoom: 1;
-	overflow: auto;
 
-	// &:before,
-	// &:after {
-	// 	content: ' ';
-	// 	display: table;
-	// }
-	// &:after {
-	// 	clear: both;
-	// }
+	&:before,
+	&:after {
+		content: ' ';
+		display: table;
+	}
+	&:after {
+		clear: both;
+	}
 
 	// Serve a fixed-width layout to IE8
 	@include oGridTargetIE8 {

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -455,12 +455,14 @@
 }
 
 /// Reset row styles
-@mixin oGridRowReset {
+@mixin oGridRowReset($total-cols: $o-grid-columns) {
+	$subgrid-ratio: $o-grid-columns / $total-cols;
+
 	width: auto;
 	min-width: 0;
 	max-width: none;
-	margin-left: percentage(-$o-grid-gutter / 2);
-	margin-right: percentage(-$o-grid-gutter / 2);
+	margin-left: percentage($subgrid-ratio * -$o-grid-gutter / 2);
+	margin-right: percentage($subgrid-ratio * -$o-grid-gutter / 2);
 }
 
 /// Center column

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -459,8 +459,8 @@
 	width: auto;
 	min-width: 0;
 	max-width: none;
-	margin-left: -$o-grid-gutter / 2;
-	margin-right: -$o-grid-gutter / 2;
+	margin-left: percentage(-$o-grid-gutter / 2);
+	margin-right: percentage(-$o-grid-gutter / 2);
 }
 
 /// Center column

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -15,7 +15,7 @@
 @mixin oGridAddLayout($layout-name, $column-width: null, $layout-width: null) {
 	@if $column-width {
 		@warn 'Defining a layout by column-width is deprecated, use $layout-width instead (would be 120 + 12*$column-width by default)';
-		@return;
+		$layout-width: 120px + 12*$column-width; // best guess
 	}
 
 	$temp-layouts: ();

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -14,7 +14,8 @@
 /// @param {String} $layout-width [null]
 @mixin oGridAddLayout($layout-name, $column-width: null, $layout-width: null) {
 	@if $column-width {
-		$layout-width: _oGridWidth($column-width);
+		@warn 'Defining a layout by column-width is deprecated, use $layout-width instead (would be 120 + 12*$column-width by default)';
+		@return;
 	}
 
 	$temp-layouts: ();

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -89,16 +89,25 @@
 	@if $span == 'full-width' {
 		@return 100%;
 	} @else {
-		@if $span >= 1 {
-			// A number of columns is supplied: converting it into a fraction
-			// of the total number of columns
-			@return percentage($span / $total-cols);
-		} @else {
-			// A fraction (1/2) or a number (0.5) is supplied:
-			// converting it into a percentage
-			@return percentage($span);
-		}
+		@return oGridSpan($span, $total-cols, 0);
 	}
+}
+
+/// Private utility function for the calculation of spans
+@function oGridSpan($span, $total-cols, $gutters: 0) {
+	@if $span < 1 {
+		// A fraction (1/2) or a number (0.5) is supplied:
+		// converting it into a percentage
+		@if round($span * $total-cols) != ($span * $total-cols) {
+			@error "Colspan #{$span} doesn't result in an integer column number (= #{$span * $total-cols}).";
+		}
+
+		$span: $span * $total-cols;
+	}
+
+	// final width of the grid item
+	$subgrid-ratio: $o-grid-columns / $total-cols;
+	@return percentage($subgrid-ratio * ($span * $o-grid-column + ($span + $gutters) * $o-grid-gutter))
 }
 
 /// Alias for the oGridColspan function
@@ -263,16 +272,28 @@
 ///   el { @include oGridColumn((default: 12, M: 8, L: hide)); }
 ///
 /// @param {Number | Map} $span [null]
-@mixin oGridColumn($span: null) {
+@mixin oGridColumn($span: null, $total-cols: $o-grid-columns) {
 	position: relative; // Required for push and pull
-	padding-left: $o-grid-gutter / 2;
-	padding-right: $o-grid-gutter / 2;
 	float: left;
 	box-sizing: border-box;
+	min-height: 1px;
+
+	@include oGridColumnMargins($total-cols);
 
 	@if $span {
-		@include oGridColspan($span);
+		@include oGridColspan($span, $total-cols);
 	}
+}
+
+@mixin oGridColumnMargins($total-cols: $o-grid-columns) {
+	$subgrid-ratio: $o-grid-columns / $total-cols;
+
+	// assymetry to prevent margins from collapsing
+	margin-top: 0;
+	margin-bottom: percentage($subgrid-ratio * $o-grid-gutter);
+
+	padding-right: percentage($subgrid-ratio * $o-grid-gutter / 2);
+	padding-left: percentage($subgrid-ratio * $o-grid-gutter / 2);
 }
 
 /// Cross browser column widths across layouts
@@ -283,7 +304,7 @@
 ///   el { @include oGridColspan((default: 12, M: 8, L: hide)); }
 ///
 /// @param {Number | Map} $span
-@mixin oGridColspan($span) {
+@mixin oGridColspan($span, $total-cols: $o-grid-columns) {
 	// Special case: the column is hidden by default
 	@if $span == 'hide' {
 		display: none;
@@ -291,10 +312,10 @@
 		// $span is a number or a keyword, so we're outputting the default width for that column
 		@if type-of($span) == number or type-of($span) == string {
 			@include oGridTargetIE8 {
-				width: oGridColspan($span);
+				width: oGridColspan($span, $total-cols);
 			}
 			@include oGridTargetModernBrowsers {
-				width: oGridColspan($span);
+				width: oGridColspan($span, $total-cols);
 			}
 		}
 	}
@@ -308,11 +329,11 @@
 				} @else {
 					@include oGridTargetIE8 {
 						display: block;
-						width: oGridColspan($layout-span);
+						width: oGridColspan($layout-span, $total-cols);
 					}
 					@include oGridTargetModernBrowsers {
 						display: block;
-						width: oGridColspan($layout-span);
+						width: oGridColspan($layout-span, $total-cols);
 					}
 				}
 			} @else {
@@ -331,12 +352,12 @@
 					@if index($_o-grid-layout-names, $layout-name) <= index($_o-grid-layout-names, $o-grid-fixed-layout) {
 						@include oGridTargetIE8 {
 							display: block;
-							width: oGridColspan($layout-span);
+							width: oGridColspan($layout-span, $total-cols);
 						}
 					}
 					@include oGridRespondTo($layout-name) {
 						display: block;
-						width: oGridColspan($layout-span);
+						width: oGridColspan($layout-span, $total-cols);
 					}
 				}
 			}
@@ -352,19 +373,30 @@
 	@include oGridColspan($span);
 }
 
+@mixin oGridRowMargins($total-cols: $o-grid-columns) {
+	$subgrid-ratio: ($o-grid-columns + 1) / ($total-cols + 1);
+
+	margin-right: auto;
+	margin-left: auto;
+	margin-top: 0;
+
+	padding-bottom: percentage($subgrid-ratio * $o-grid-gutter);
+
+	// swallow column bottom margin
+	margin-bottom: percentage($subgrid-ratio * -$o-grid-gutter);
+}
+
 /// Base row styles
 ///
 /// @param {String} $grid-mode [$o-grid-mode]
-@mixin oGridRow($grid-mode: $o-grid-mode) {
+@mixin oGridRow($grid-mode: $o-grid-mode, $total-cols: $o-grid-columns) {
 	clear: both;
 	min-width: $o-grid-min-width;
 	// Older browsers get a fixed-width layout
 	max-width: oGridGetMaxWidthForLayout($o-grid-fixed-layout);
-	padding-left: $o-grid-gutter / 2;
-	padding-right: $o-grid-gutter / 2;
 	box-sizing: border-box;
-	margin-left: auto;
-	margin-right: auto;
+
+	@include oGridRowMargins($total-cols);
 
 	// Clearfix
 	zoom: 1;
@@ -434,8 +466,6 @@
 	max-width: none;
 	margin-left: -$o-grid-gutter / 2;
 	margin-right: -$o-grid-gutter / 2;
-	padding-left: 0;
-	padding-right: 0;
 }
 
 /// Center column
@@ -454,8 +484,12 @@
 
 /// Remove column styles
 @mixin oGridResetColumn {
-	padding-left: 0;
 	padding-right: 0;
+	padding-left: 0;
+	margin-top: 0;
+	margin-bottom: 0;
+	padding-bottom: 0;
+
 	float: none;
 	width: auto;
 }
@@ -463,24 +497,24 @@
 /// Reorder visually: pull
 ///
 /// @param {Number} $columns
-@mixin oGridPull($columns) {
-	right: oGridColspan($columns);
+@mixin oGridPull($columns, $total-cols: $o-grid-columns) {
+	right: oGridColspan($columns, $total-cols);
 	left: auto;
 }
 
 /// Reorder visually: push
 ///
 /// @param {Number} $columns
-@mixin oGridPush($columns) {
-	left: oGridColspan($columns);
+@mixin oGridPush($columns, $total-cols: $o-grid-columns) {
+	left: oGridColspan($columns, $total-cols);
 	right: auto;
 }
 
 /// Offset: add space before a column
 ///
 /// @param {Number} $columns
-@mixin oGridOffset($columns) {
-	margin-left: oGridColspan($columns);
+@mixin oGridOffset($columns, $total-cols: $o-grid-columns) {
+	margin-left: oGridSpan($columns, $total-cols, 1);
 }
 
 /// Remove row styles
@@ -549,7 +583,7 @@
 			display: block;
 
 			// Apply width in %
-			width: oGridColspan($colspan, $o-grid-columns);
+			width: oGridColspan($colspan);
 		}
 	}
 

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -288,9 +288,8 @@
 @mixin oGridColumnMargins($total-cols: $o-grid-columns) {
 	$subgrid-ratio: $o-grid-columns / $total-cols;
 
-	// assymetry to prevent margins from collapsing
-	margin-top: 0;
-	margin-bottom: percentage($subgrid-ratio * $o-grid-gutter);
+	padding-top: percentage($subgrid-ratio * $o-grid-gutter / 2);
+	padding-bottom: percentage($subgrid-ratio * $o-grid-gutter / 2);
 
 	padding-right: percentage($subgrid-ratio * $o-grid-gutter / 2);
 	padding-left: percentage($subgrid-ratio * $o-grid-gutter / 2);
@@ -374,16 +373,10 @@
 }
 
 @mixin oGridRowMargins($total-cols: $o-grid-columns) {
-	$subgrid-ratio: ($o-grid-columns + 1) / ($total-cols + 1);
+	$subgrid-ratio: $o-grid-columns / $total-cols;
 
 	margin-right: auto;
 	margin-left: auto;
-	margin-top: 0;
-
-	padding-bottom: percentage($subgrid-ratio * $o-grid-gutter);
-
-	// swallow column bottom margin
-	margin-bottom: percentage($subgrid-ratio * -$o-grid-gutter);
 }
 
 /// Base row styles
@@ -400,15 +393,16 @@
 
 	// Clearfix
 	zoom: 1;
+	overflow: auto;
 
-	&:before,
-	&:after {
-		content: ' ';
-		display: table;
-	}
-	&:after {
-		clear: both;
-	}
+	// &:before,
+	// &:after {
+	// 	content: ' ';
+	// 	display: table;
+	// }
+	// &:after {
+	// 	clear: both;
+	// }
 
 	// Serve a fixed-width layout to IE8
 	@include oGridTargetIE8 {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -58,41 +58,33 @@ $o-grid-ie8-rules: 'inline' !default;
 /// @type Number (unitless)
 $o-grid-columns: 12 !default;
 
-/// Gutter size, in pixels
+/// Gutter size, fractional
 ///
-/// @type Number
-$o-grid-gutter: 10px !default;
+/// @type Number (unitless)
+$o-grid-column: 90 / 1200 !default;
+
+/// Gutter size, fractional
+///
+/// @type Number (unitless)
+$o-grid-gutter: 10 / 1200 !default;
 
 /// Minimum width, in pixels
 ///
 /// @type Number
 $o-grid-min-width: 240px !default;
 
-/// Full width of the grid: combined width of columns, gutters and outer margins
-/// for a specific column width
-///
-/// @access private
-///
-/// @param {Number} column-width - desired width of a grid column
-///
-/// @returns {Number} width of the grid, in pixels
-@function _oGridWidth($column-width) {
-	$gutters-combined-width: $o-grid-gutter * ($o-grid-columns - 1) + 0px;
-	$outer-margins-combined-width: $o-grid-gutter * 2 + 0px;
-	@return ($column-width * $o-grid-columns) + $gutters-combined-width + $outer-margins-combined-width;
-}
-
 /// Layouts
 ///
-/// Each layout is calculated following a specific column width,
-/// in order to base breakpoints on the structure of the grid itself
+/// Each layout is width divisible by $o-grid-columns
+/// in order to base the flexible columns and gutters
+/// on the total width of the grid
 ///
 /// @type Map
 $o-grid-layouts: (
-	S:  _oGridWidth($column-width: 30px), // 490px
-	M:  _oGridWidth($column-width: 50px), // 730px
-	L:  _oGridWidth($column-width: 70px), // 970px
-	XL: _oGridWidth($column-width: 90px)  // 1210px
+	S: 480px,
+	M: 720px,
+	L: 960px,
+	XL: 1200px,
 ) !default;
 
 /// Layout names


### PR DESCRIPTION
We've been talking about this for a while and here it finally is - the flexible gutter grid. For those who never heard of it, this came out of [next-front-page](/Financial-Times/next-front-page) and the realisation that we need an extra breakpoint at around 1440px for people on 1920 by 1080 screens (which is quite a few, I can find the numbers if anyone's interested). 

With such a big spread between the top and the bottom breakpoint, fixed-width gutters no longer work. Based on the prototype we did for Next front page, this updates o-grid to use the same geometry while trying to keep everything as close to original as I possibly could.

The major change is that the layouts are now defined by constant width and the columns/gutters are sized relatively - the default at 1200 stays the same. Because of the way the calculations work (and to keep my sanity), I changed all the default breakpoints to be one gutter - 10px - narrower (thus being divisible by 12) and the extra gutter space before the first and after the last column are now a half gutter, not a full one. For backwards compatibility it would be possible to add a half-gutter padding on the `o-grid-row` to get back up to the original dimensions, but the column and gutter definitions get a bit awkward in relation to the layout definition (e.g. column = 90/1200, gutter = 10/1200, layout = 1210px. What.).

As a new thing, the columns also have a flexible padding above and below them to repeat the grid rhythm vertically (as a side effect, the test in demos looks slightly different - the white space between rows is gone in favour of the column defined spacing).

Unless everyone is very much against the general idea of this, we need to figure out how to roll this out without breaking every user of `o-grid` (hopefully just a major revision). But if the changes are a bit too radical, there is the option of forking as `n-grid`, test on Next and merge back to `o-grid` later on.

/cc @kaelig @keirog @commuterjoy 

# To Do

- [x] Flexible gutters as well as columns
- [x] Keep the same metrics at 1200
- [x] Update the geometry tests
- [x] Make row spaces gutter height
- [x] Add a test case to show how to do same-height columns with flex box (and resolve differences between Gecko and WebKit)
- [x] Switch next-front-page to this o-grid branch and make sure everything works (Financial-Times/next-front-page#129)
- [ ] Plan versioning or forking as n-grid