### PR TITLE
Stop breaking print layout in Friefox

### DIFF
--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -480,6 +480,9 @@
 		display: -webkit-flex;
 		display: -ms-flexbox;
 		display: flex;
+		@media print {
+			display: inherit;
+		}
 	}
 
 	@if $o-grid-mode == 'fixed' {


### PR DESCRIPTION
Whilst fixing the print layout for articles in Next I tracked down an issue with page breaks at unintended points and text not flowing onto subsequent pages.

Removing the display flex from o-grid-row for print media, resolves this.