### PR TITLE
Update demos

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -20,31 +20,27 @@
 		{
 			"name": "default",
 			"sass": "demos/src/scss/default.scss",
-			"expanded": true,
 			"description": "Grid with all default settings"
 		},
 		{
 			"name": "snappy",
 			"sass": "demos/src/scss/snappy.scss",
-			"expanded": false,
 			"description": "Responsive grid that snaps between a larger fixed layout at each breakpoint"
 		},
 		{
 			"name": "resized",
 			"sass": "demos/src/scss/resized.scss",
-			"expanded": false,
 			"description": "Responsive grid with breakpoints reallocated to 400px, 800px and 1000px and gutters halved"
 		},
 		{
 			"name": "always-fixed",
 			"sass": "demos/src/scss/always-fixed.scss",
-			"expanded": false,
 			"description": "Fixed grid at 610px across all browsers and devices.  Should always be fixed at the large layout"
 		},
 		{
 			"name": "ie8",
 			"sass": "demos/src/scss/ie8.scss",
-			"expanded": false,
+			"hidden": true,
 			"description": "Forced IE 8 experience, where the width of the grid is fixed to be a M layout"
 		},
 		{
@@ -52,7 +48,7 @@
 			"template": "demos/src/test.mustache",
 			"js": "demos/src/js/style-switcher.js",
 			"sass": "demos/src/scss/default.scss",
-			"expanded": false,
+			"hidden": true,
 			"description": "test demo",
 			"data": "demos/src/configurations.json",
 			"documentClasses": "test",


### PR DESCRIPTION
Hide the `test` and `ie8` demos.

Removes the deprecated `expanded` property.