### PR TITLE
➕ Adds ability to listen to layout change events

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,35 @@ When using o-grid silent mode, make sure to surface the grid
 information to make it readable by the JavaScript Helper
 by adding `@include oGridSurfaceCurrentLayout();` to your Sass file.
 
+### `getGridBreakpoints()`
+
+Returns the sizes of all grid breakpoints available.
+
+```js
+var oGrid = require('o-grid');
+
+console.log(oGrid.getGridBreakpoints());
+// > { "layouts": { "S": "490px", "M": "740px", "L": "980px", "XL": "1220px" } }
+```
+
+When using o-grid silent mode, make sure to surface the grid
+information to make it readable by the JavaScript Helper
+by adding `@include oGridSurfaceLayoutSizes;` to your Sass file.
+
+### `addBreakpointListeners()`
+
+Configures a bunch of matchMedia queries that fire a `o-grid.layoutChange` event upon layout change.
+
+```js
+var oGrid = require('o-grid');
+
+oGrid.addBreakpointListeners();
+```
+
+When using o-grid silent mode, make sure to surface the grid
+information to make it readable by the JavaScript Helper
+by adding `@include oGridSurfaceLayoutSizes;` to your Sass file.
+
 ## Grid Bookmarklet
 
 1. Create a new Bookmark with this URL:

--- a/README.md
+++ b/README.md
@@ -635,9 +635,9 @@ When using o-grid silent mode, make sure to surface the grid
 information to make it readable by the JavaScript Helper
 by adding `@include oGridSurfaceLayoutSizes;` to your Sass file.
 
-### `addBreakpointListeners()`
+### `enableLayoutChangeEvents()`
 
-Configures a bunch of matchMedia queries that fire an `o-grid.layoutChange` event upon layout change.
+Enable matchMedia queries that fire an `o-grid.layoutChange` event upon layout change.
 
 ```js
 var oGrid = require('o-grid');

--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ by adding `@include oGridSurfaceLayoutSizes;` to your Sass file.
 
 ### `addBreakpointListeners()`
 
-Configures a bunch of matchMedia queries that fire a `o-grid.layoutChange` event upon layout change.
+Configures a bunch of matchMedia queries that fire an `o-grid.layoutChange` event upon layout change.
 
 ```js
 var oGrid = require('o-grid');

--- a/main.js
+++ b/main.js
@@ -61,5 +61,6 @@ function getCurrentGutter() {
 
 export default {
 	getCurrentLayout: getCurrentLayout,
-	getCurrentGutter: getCurrentGutter
+	getCurrentGutter: getCurrentGutter,
+	getGridProperties: getGridProperties,
 };

--- a/main.js
+++ b/main.js
@@ -83,12 +83,13 @@ function getCurrentGutter() {
 function addBreakpointListeners() {
 	try {
 		// Create a map containing all breakpoints exposed via html:before
-		const breakpoints = new Map(Object.entries(getGridBreakpoints().layouts));
+		const layouts = getGridBreakpoints().layouts;
+		const breakpoints = new Map(Object.keys(layouts).map(key => [key, layouts[key]]));
 		const decr1 = val => `${Number(val.replace('px', '') - 1)}px`;
 
 		// Generate media queries for each
 		breakpoints.forEach((width, size) => {
-			const queries = Array();
+			const queries = [];
 			if (size === 'S') {
 				queries.push(`(max-width: ${ width })`);
 				queries.push(`(min-width: ${ width }) and (max-width: ${ decr1(breakpoints.get('M')) })`);
@@ -109,7 +110,7 @@ function addBreakpointListeners() {
 						}
 					}));
 				}
-			}
+			};
 
 			// Create a new listener for each layout
 			queries.forEach(mq => {

--- a/main.js
+++ b/main.js
@@ -80,10 +80,11 @@ function getCurrentGutter() {
  * This sets MediaQueryListeners on all the o-grid breakpoints
  * and fires a `o-grid.layoutChange` event on layout change.
  */
-function addBreakpointListeners() {
-	try {
-		// Create a map containing all breakpoints exposed via html:before
-		const layouts = getGridBreakpoints().layouts;
+function enableLayoutChangeEvents() {
+	// Create a map containing all breakpoints exposed via html:before
+	const gridLayouts = getGridBreakpoints();
+	if (gridLayouts.hasOwnProperty('layouts')) {
+		const layouts = gridLayouts.layouts;
 		const breakpoints = new Map(Object.keys(layouts).map(key => [key, layouts[key]]));
 		const decr1 = val => `${Number(val.replace('px', '') - 1)}px`;
 
@@ -119,9 +120,8 @@ function addBreakpointListeners() {
 				handleMQChange(mql);
 			});
 		});
-	} catch (e) {
-		console.error(e);
-		return;
+	} else {
+		console.error('To enable grid layout change events, include oGridSurfaceLayoutSizes in your Sass');
 	}
 }
 
@@ -129,5 +129,5 @@ export default {
 	getCurrentLayout: getCurrentLayout,
 	getCurrentGutter: getCurrentGutter,
 	getGridBreakpoints: getGridBreakpoints,
-	addBreakpointListeners: addBreakpointListeners,
+	enableLayoutChangeEvents: enableLayoutChangeEvents,
 };

--- a/main.js
+++ b/main.js
@@ -18,14 +18,31 @@ const isIE8 = (function() {
 }());
 
 /**
- * Grab grid properties surfaced in html:after's content
+ * Grab grid properties
  * @return {Object} layout names and gutter widths
  */
 function getGridProperties() {
+	return getGridFromDoc('after');
+}
+
+/**
+ * Get all layout sizes
+ * @return {Object} layout names and sizes
+ */
+function getGridBreakpoints() {
+	return getGridFromDoc('before');
+}
+
+/**
+ * Grab grid properties surfaced in html:after and html:before's content
+ * @param {String} position Whether to get all properties in :before, or current properties in :after
+ * @return {Object} layout names and gutter widths
+ */
+function getGridFromDoc(position) {
 	// Contained in a try/catch as it should not error if o-grid styles are not (deliberately or accidentally) loaded
 	// e.g. o-tracking will always try to read this property, but the page is not obliged to use o-grid for layout
 	try {
-		let gridProperties = window.getComputedStyle(document.documentElement, ':after').getPropertyValue('content');
+		let gridProperties = window.getComputedStyle(document.documentElement, ':' + position).getPropertyValue('content');
 		// Firefox computes: "{\"foo\": \"bar\"}"
 		// We want readable JSON: {"foo": "bar"}
 		gridProperties = gridProperties.replace(/'/g, '').replace(/\\/g, '').replace(/^"/, '').replace(/"$/, '');
@@ -59,8 +76,57 @@ function getCurrentGutter() {
 	return getGridProperties().gutter;
 }
 
+/**
+ * This sets MediaQueryListeners on all the o-grid breakpoints
+ * and fires a `o-grid.layoutChange` event on layout change.
+ */
+function addBreakpointListeners() {
+	try {
+		// Create a map containing all breakpoints exposed via html:before
+		const breakpoints = new Map(Object.entries(getGridBreakpoints().layouts));
+		const decr1 = val => `${Number(val.replace('px', '') - 1)}px`;
+
+		// Generate media queries for each
+		breakpoints.forEach((width, size) => {
+			const queries = Array();
+			if (size === 'S') {
+				queries.push(`(max-width: ${ width })`);
+				queries.push(`(min-width: ${ width }) and (max-width: ${ decr1(breakpoints.get('M')) })`);
+			} else if (size === 'M') {
+				queries.push(`(min-width: ${ width }) and (max-width: ${ decr1(breakpoints.get('L')) })`);
+			} else if (size === 'L') {
+				queries.push(`(min-width: ${ width }) and (max-width: ${ decr1(breakpoints.get('XL')) })`);
+			} else if (size === 'XL') {
+				queries.push(`(min-width: ${ width })`);
+			}
+
+			// matchMedia listener handler: Dispatch `o-grid.layoutChange` event if a match
+			const handleMQChange = mql => {
+				if (mql.matches) {
+					window.dispatchEvent(new CustomEvent('o-grid.layoutChange', {
+						detail: {
+							layout: size,
+						}
+					}));
+				}
+			}
+
+			// Create a new listener for each layout
+			queries.forEach(mq => {
+				const mql = window.matchMedia(mq);
+				mql.addListener(handleMQChange);
+				handleMQChange(mql);
+			});
+		});
+	} catch (e) {
+		console.error(e);
+		return;
+	}
+}
+
 export default {
 	getCurrentLayout: getCurrentLayout,
 	getCurrentGutter: getCurrentGutter,
-	getGridProperties: getGridProperties,
+	getGridBreakpoints: getGridBreakpoints,
+	addBreakpointListeners: addBreakpointListeners,
 };

--- a/main.scss
+++ b/main.scss
@@ -50,8 +50,31 @@
 	}
 }
 
+@mixin oGridSurfaceLayoutSizes {
+	html:before {
+		$breakpoints: ();
+		$combined: unquote("");
+
+		@each $layout, $size in $o-grid-layouts {
+			$breakpoints: append($breakpoints, '"#{$layout}": "#{$size}"');
+		}
+
+		@for $i from 1 through length($breakpoints) {
+			@if $i < length($breakpoints) {
+				$combined: $combined + nth($breakpoints, $i) + ", ";
+			} @else {
+				$combined: $combined + nth($breakpoints, $i);
+			}
+		}
+
+		display: none;
+		content: '{ "layouts": { #{$combined} } }';
+	}
+}
+
 @if $o-grid-is-silent == false {
 	@include oGridSurfaceCurrentLayout;
+	@include oGridSurfaceLayoutSizes;
 	@include oGridGenerate;
 
 	// Turn silent mode back on to avoid outputting the grid twice

--- a/main.scss
+++ b/main.scss
@@ -59,11 +59,11 @@
 			$breakpoints: append($breakpoints, '"#{$layout}": "#{$size}"');
 		}
 
-		@for $i from 1 through length($breakpoints) {
-			@if $i < length($breakpoints) {
-				$combined: $combined + nth($breakpoints, $i) + ", ";
+		@for $ittr from 1 through length($breakpoints) {
+			@if $ittr < length($breakpoints) {
+				$combined: $combined + nth($breakpoints, $ittr) + ", ";
 			} @else {
-				$combined: $combined + nth($breakpoints, $i);
+				$combined: $combined + nth($breakpoints, $ittr);
 			}
 		}
 

--- a/origami.json
+++ b/origami.json
@@ -7,7 +7,8 @@
 	"supportStatus": "active",
 	"browserFeatures": {
 		"required": [
-		"css-boxsizing"
+		"css-boxsizing",
+		"Map"
 		]
 	},
 	"ci": {


### PR DESCRIPTION
My colleague and I are working on a project for the homepage front page that needs to respond to changing `o-grid` breakpoints, and we could either use getCurrentLayout() in a listening on `window.onresize`, which will call `getGridProperties()` continuously, or we could call `getGridProperties()` once during initialisation and then use `window.matchMedia` based on those values.

To that latter end, this PR.
