### PR TITLE
bump to v5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,6 @@
     "main.js"
   ],
   "dependencies": {
-    "sass-mq": "^3.1.0"
-  },
-  "ignore" : []
+    "sass-mq": "^5.0.0"
+	}
 }


### PR DESCRIPTION
By the looks of it, we use one mixin provided by the `sass-mq` API (`mq()`) which remains unchanged from v3.