### PR TITLE
change autoprefixer control comments

### DIFF
--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -301,14 +301,18 @@
 		position: relative; // Required for push and pull
 		float: left;
 		flex: 1 1 0%;
-		// Turn autoprefixer off for the box-sizing rules
-		// in order to fix positioning on older browsers.
-		/*autoprefixer: off*/
+
+		// Autoprefixer doesn't generate -moz-box-sizing, so we need to
+		// set the vendor prefixes and then ignore the property to be
+		// prefixed, in order to avoid overwrites—the order of the properties is
+		// reversed because otherwise autoprefixer doesn't kick in (╯°□°）╯︵ ┻━┻
+		// issue: https://github.com/Financial-Times/o-grid/issues/175
 		// sass-lint:disable no-vendor-prefixes
 		-webkit-box-sizing: border-box;
 		-moz-box-sizing: border-box;
-		box-sizing: border-box;
 		// sass-lint:enable no-vendor-prefixes
+		/*autoprefixer: ignore-next*/
+		box-sizing: border-box;
 
 		@include oGridTargetIE8 {
 			min-width: 0 !important; // sass-lint:disable-line no-important
@@ -424,14 +428,17 @@
 	// Older browsers get a fixed-width layout
 	max-width: oGridGetMaxWidthForLayout($o-grid-fixed-layout);
 
-	// Turn autoprefixer off for the box-sizing rules
-	// in order to fix positioning on older browsers.
-	/*autoprefixer: off*/
+	// Autoprefixer doesn't generate -moz-box-sizing, so we need to
+	// set the vendor prefixes and then ignore the property to be
+	// prefixed, in order to avoid overwrites—the order of the properties is
+	// reversed because otherwise autoprefixer doesn't kick in (╯°□°）╯︵ ┻━┻
+	// issue: https://github.com/Financial-Times/o-grid/issues/175
 	// sass-lint:disable no-vendor-prefixes
 	-webkit-box-sizing: border-box;
 	-moz-box-sizing: border-box;
-	box-sizing: border-box;
 	// sass-lint:enable no-vendor-prefixes
+	/*autoprefixer: ignore-next*/
+	box-sizing: border-box;
 
 	@if $bleed {
 		padding-left: 0;

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -301,17 +301,6 @@
 		position: relative; // Required for push and pull
 		float: left;
 		flex: 1 1 0%;
-
-		// Autoprefixer doesn't generate -moz-box-sizing, so we need to
-		// set the vendor prefixes and then ignore the property to be
-		// prefixed, in order to avoid overwrites—the order of the properties is
-		// reversed because otherwise autoprefixer doesn't kick in (╯°□°）╯︵ ┻━┻
-		// issue: https://github.com/Financial-Times/o-grid/issues/175
-		// sass-lint:disable no-vendor-prefixes
-		-webkit-box-sizing: border-box;
-		-moz-box-sizing: border-box;
-		// sass-lint:enable no-vendor-prefixes
-		/*autoprefixer: ignore-next*/
 		box-sizing: border-box;
 
 		@include oGridTargetIE8 {
@@ -421,24 +410,13 @@
 /// @param {String} $grid-mode [$o-grid-mode]
 /// @param {Boolean} $bleed [false]
 @mixin oGridContainer($grid-mode: $o-grid-mode, $bleed: false) {
-	position: relative;
+	box-sizing: border-box;
 	margin-left: auto;
 	margin-right: auto;
 	min-width: $o-grid-min-width;
 	// Older browsers get a fixed-width layout
 	max-width: oGridGetMaxWidthForLayout($o-grid-fixed-layout);
-
-	// Autoprefixer doesn't generate -moz-box-sizing, so we need to
-	// set the vendor prefixes and then ignore the property to be
-	// prefixed, in order to avoid overwrites—the order of the properties is
-	// reversed because otherwise autoprefixer doesn't kick in (╯°□°）╯︵ ┻━┻
-	// issue: https://github.com/Financial-Times/o-grid/issues/175
-	// sass-lint:disable no-vendor-prefixes
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
-	// sass-lint:enable no-vendor-prefixes
-	/*autoprefixer: ignore-next*/
-	box-sizing: border-box;
+	position: relative;
 
 	@if $bleed {
 		padding-left: 0;

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -298,10 +298,10 @@
 /// @param {Number | Map} $span [null]
 @mixin oGridColspan($span: null, $width-only: false) {
 	@if not $width-only {
-		position: relative; // Required for push and pull
+		box-sizing: border-box;
 		float: left;
 		flex: 1 1 0%;
-		box-sizing: border-box;
+		position: relative; // Required for push and pull
 
 		@include oGridTargetIE8 {
 			min-width: 0 !important; // sass-lint:disable-line no-important

--- a/test/scss/_fixed-grid.test.scss
+++ b/test/scss/_fixed-grid.test.scss
@@ -30,16 +30,10 @@ $o-grid-mode: 'fixed';
 
 				@include expect($selector: false) {
 					.test-colspan {
-						position: relative;
+						box-sizing: border-box;
 						float: left;
 						flex: 1 1 0%;
-						// sass-lint:disable no-vendor-prefixes
-						-webkit-box-sizing: border-box;
-						-moz-box-sizing: border-box;
-						// sass-lint:enable no-vendor-prefixes
-						/*autoprefixer: ignore-next*/
-						box-sizing: border-box;
-
+						position: relative;
 						padding-left: 20px;
 					}
 
@@ -64,17 +58,12 @@ $o-grid-mode: 'fixed';
 
 				@include expect($selector: false) {
 					.test-container {
-						position: relative;
+						box-sizing: border-box;
 						margin-left: auto;
 						margin-right: auto;
 						min-width: 240px;
 						max-width: 980px;
-						// sass-lint:disable no-vendor-prefixes
-						-webkit-box-sizing: border-box;
-						-moz-box-sizing: border-box;
-						// sass-lint:enable no-vendor-prefixes
-						/*autoprefixer: ignore-next*/
-						box-sizing: border-box;
+						position: relative;
 						width: 980px; // sass-lint:disable-line no-duplicate-properties
 						padding-left: 20px;
 						padding-right: 20px;
@@ -93,17 +82,12 @@ $o-grid-mode: 'fixed';
 
 				@include expect($selector: false) {
 					.test-container {
-						position: relative;
+						box-sizing: border-box;
 						margin-left: auto;
 						margin-right: auto;
 						min-width: 240px;
 						max-width: 980px;
-						// sass-lint:disable no-vendor-prefixes
-						-webkit-box-sizing: border-box;
-						-moz-box-sizing: border-box;
-						// sass-lint:enable no-vendor-prefixes
-						/*autoprefixer: ignore-next*/
-						box-sizing: border-box;
+						position: relative;
 						padding-left: 0;
 						padding-right: 0;
 						width: 980px; // sass-lint:disable-line no-duplicate-properties

--- a/test/scss/_fixed-grid.test.scss
+++ b/test/scss/_fixed-grid.test.scss
@@ -33,12 +33,13 @@ $o-grid-mode: 'fixed';
 						position: relative;
 						float: left;
 						flex: 1 1 0%;
-						/*autoprefixer: off*/
 						// sass-lint:disable no-vendor-prefixes
 						-webkit-box-sizing: border-box;
 						-moz-box-sizing: border-box;
-						box-sizing: border-box;
 						// sass-lint:enable no-vendor-prefixes
+						/*autoprefixer: ignore-next*/
+						box-sizing: border-box;
+
 						padding-left: 20px;
 					}
 
@@ -68,12 +69,12 @@ $o-grid-mode: 'fixed';
 						margin-right: auto;
 						min-width: 240px;
 						max-width: 980px;
-						/*autoprefixer: off*/
 						// sass-lint:disable no-vendor-prefixes
 						-webkit-box-sizing: border-box;
 						-moz-box-sizing: border-box;
-						box-sizing: border-box;
 						// sass-lint:enable no-vendor-prefixes
+						/*autoprefixer: ignore-next*/
+						box-sizing: border-box;
 						width: 980px; // sass-lint:disable-line no-duplicate-properties
 						padding-left: 20px;
 						padding-right: 20px;
@@ -97,12 +98,12 @@ $o-grid-mode: 'fixed';
 						margin-right: auto;
 						min-width: 240px;
 						max-width: 980px;
-						/*autoprefixer: off*/
 						// sass-lint:disable no-vendor-prefixes
 						-webkit-box-sizing: border-box;
 						-moz-box-sizing: border-box;
-						box-sizing: border-box;
 						// sass-lint:enable no-vendor-prefixes
+						/*autoprefixer: ignore-next*/
+						box-sizing: border-box;
 						padding-left: 0;
 						padding-right: 0;
 						width: 980px; // sass-lint:disable-line no-duplicate-properties

--- a/test/scss/_fluid-grid.test.scss
+++ b/test/scss/_fluid-grid.test.scss
@@ -177,12 +177,12 @@
 						position: relative;
 						float: left;
 						flex: 1 1 0%;
-						/*autoprefixer: off*/
 						// sass-lint:disable no-vendor-prefixes
 						-webkit-box-sizing: border-box;
 						-moz-box-sizing: border-box;
-						box-sizing: border-box;
 						// sass-lint:enable no-vendor-prefixes
+						/*autoprefixer: ignore-next*/
+						box-sizing: border-box;
 						padding-left: 10px;
 					}
 
@@ -244,12 +244,12 @@
 						margin-right: auto;
 						min-width: 240px;
 						max-width: 1220px;
-						/*autoprefixer: off*/
 						// sass-lint:disable no-vendor-prefixes
 						-webkit-box-sizing: border-box;
 						-moz-box-sizing: border-box;
-						box-sizing: border-box;
 						// sass-lint:enable no-vendor-prefixes
+						/*autoprefixer: ignore-next*/
+						box-sizing: border-box;
 						max-width: 1220px; // sass-lint:disable-line no-duplicate-properties
 						padding-left: 10px;
 						padding-right: 10px;
@@ -309,12 +309,12 @@
 						margin-right: auto;
 						min-width: 240px;
 						max-width: 1220px;
-						/*autoprefixer: off*/
 						// sass-lint:disable no-vendor-prefixes
 						-webkit-box-sizing: border-box;
 						-moz-box-sizing: border-box;
-						box-sizing: border-box;
 						// sass-lint:enable no-vendor-prefixes
+						/*autoprefixer: ignore-next*/
+						box-sizing: border-box;
 						padding-left: 0;
 						padding-right: 0;
 						max-width: 1220px; // sass-lint:disable-line no-duplicate-properties

--- a/test/scss/_fluid-grid.test.scss
+++ b/test/scss/_fluid-grid.test.scss
@@ -174,15 +174,10 @@
 
 				@include expect($selector: false) {
 					.test-colspan {
-						position: relative;
+						box-sizing: border-box;
 						float: left;
 						flex: 1 1 0%;
-						// sass-lint:disable no-vendor-prefixes
-						-webkit-box-sizing: border-box;
-						-moz-box-sizing: border-box;
-						// sass-lint:enable no-vendor-prefixes
-						/*autoprefixer: ignore-next*/
-						box-sizing: border-box;
+						position: relative;
 						padding-left: 10px;
 					}
 
@@ -239,17 +234,12 @@
 
 				@include expect($selector: false) {
 					.test-container {
-						position: relative;
+						box-sizing: border-box;
 						margin-left: auto;
 						margin-right: auto;
 						min-width: 240px;
 						max-width: 1220px;
-						// sass-lint:disable no-vendor-prefixes
-						-webkit-box-sizing: border-box;
-						-moz-box-sizing: border-box;
-						// sass-lint:enable no-vendor-prefixes
-						/*autoprefixer: ignore-next*/
-						box-sizing: border-box;
+						position: relative;
 						max-width: 1220px; // sass-lint:disable-line no-duplicate-properties
 						padding-left: 10px;
 						padding-right: 10px;
@@ -304,17 +294,12 @@
 
 				@include expect($selector: false) {
 					.test-container {
-						position: relative;
+						box-sizing: border-box;
 						margin-left: auto;
 						margin-right: auto;
 						min-width: 240px;
 						max-width: 1220px;
-						// sass-lint:disable no-vendor-prefixes
-						-webkit-box-sizing: border-box;
-						-moz-box-sizing: border-box;
-						// sass-lint:enable no-vendor-prefixes
-						/*autoprefixer: ignore-next*/
-						box-sizing: border-box;
+						position: relative;
 						padding-left: 0;
 						padding-right: 0;
 						max-width: 1220px; // sass-lint:disable-line no-duplicate-properties


### PR DESCRIPTION
This is meant to be a temporary patch until we have more information about the browsers that could be affected by this change. The reasoning behind this is explained in #175 