### PR TITLE
Restore `oGridSurfaceLayoutSizes` mixin and improve documentation.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,20 +11,17 @@ IE8 is no longer supported, remove uses of:
 
 The following Sass mixins and variables have been removed. Replace them with a single call to `oGrid` with the relevant options. See [the README](./README.md) for more details:
 - `oGridGenerate`
-- `oGridSurfaceLayoutSizes`
 - `$o-grid-shuffle-selectors`
 - `$o-grid-human-friendly-selectors`
 
 ```diff
 -$o-grid-human-friendly-selectors: true;
 -$o-grid-shuffle-selectors: true;
--@include oGridSurfaceLayoutSizes();
 -@include oGridGenerate();
 +@include oGrid($opts: (
 +	'bleed': true,
 +	'shuffle-selectors': true,
 +	'friendly-selectors': true,
-+	'surface': ('current-layout', 'layout-sizes'),
 +	'rows': ('compact')
 +));
 ```

--- a/README.md
+++ b/README.md
@@ -234,6 +234,19 @@ To include all styles call the `oGrid` mixin.
 ));
 ```
 
+If you would not like to use `o-grid` markup at all, the styles for the `surface` option may be included independently to enable JavaScript features:
+
+```scss
+// Surface current breakpoint and gutter size information to JavaScript.
+// Supports `getGridBreakpoints` and `enableLayoutChangeEvents`
+// JavaScript methods.
+@include oGridSurfaceLayoutSizes();
+
+// Surface grid breakpoints to JavaScript.
+// Supports the `getCurrentLayout` and `getCurrentGutter` JavaScript methods.
+@include oGridSurfaceCurrentLayout();
+```
+
 ## Advanced usage
 
 ### Utilities
@@ -654,6 +667,8 @@ console.log(oGrid.getCurrentLayout());
 // > default | S | M | L | XL
 ```
 
+CSS must be included so JavaScript can retrieve layout information. If using [Sass](#sass) and the `oGrid` mixin, ensure the `surface` [option](#options) includes `current-layout`; or include the `oGridSurfaceCurrentLayout` mixin if your project is not using any o-grid markup.
+
 ### `getCurrentGutter()`
 
 Returns the width of the gutter currently displayed.
@@ -665,7 +680,7 @@ console.log(oGrid.getCurrentGutter());
 // > 10px | 20px
 ```
 
-If using [Sass](#sass), ensure the `surface` option includes `current-layout` so JavaScript can retrieve layout information from our CSS.
+CSS must be included so JavaScript can retrieve layout information. If using [Sass](#sass) and the `oGrid` mixin, ensure the `surface` [option](#options) includes `current-layout`; or include the `oGridSurfaceCurrentLayout` mixin if your project is not using any o-grid markup.
 
 ### `getGridBreakpoints()`
 
@@ -678,7 +693,7 @@ console.log(oGrid.getGridBreakpoints());
 // > { "layouts": { "S": "490px", "M": "740px", "L": "980px", "XL": "1220px" } }
 ```
 
-If using [Sass](#sass), ensure the `surface` option includes `layout-sizes` so JavaScript can retrieve layout information from our CSS.
+CSS must be included so JavaScript can retrieve layout information. If using [Sass](#sass) and the `oGrid` mixin, ensure the `surface` [option](#options) includes `layout-sizes`; or include the `oGridSurfaceLayoutSizes` mixin if your project is not using any o-grid markup.
 
 ### `enableLayoutChangeEvents()`
 
@@ -690,7 +705,7 @@ import oGrid from 'o-grid';
 oGrid.enableLayoutChangeEvents();
 ```
 
-If using [Sass](#sass), ensure the `surface` option includes `layout-sizes` so JavaScript can retrieve layout information from our CSS.
+CSS must be included so JavaScript can retrieve layout information. If using [Sass](#sass) and the `oGrid` mixin, ensure the `surface` [option](#options) includes `layout-sizes`; or include the `oGridSurfaceLayoutSizes` mixin if your project is not using any o-grid markup.
 
 ## Grid Bookmarklet
 

--- a/main.js
+++ b/main.js
@@ -123,7 +123,7 @@ function enableLayoutChangeEvents() {
 			}
 		});
 	} else {
-		console.error('Could not enable grid layout change events. Include o-grid css. See the README for more details.');
+		console.error('Could not enable grid layout change events. Include o-grid css. See the README (https://registry.origami.ft.com/components/o-grid/readme) for more details.');
 	}
 }
 

--- a/main.js
+++ b/main.js
@@ -1,17 +1,31 @@
+const missingDataMessage = 'Could not find layout information. ' +
+	'You may need to include o-grid css. See the README ' +
+	'for more information.';
+
 /**
  * Grab grid properties
  * @return {Object} layout names and gutter widths
  */
 function getGridProperties() {
-	return getGridFromDoc('after');
+	const properties = getGridFromDoc('after');
+	if (Object.keys(properties).length === 0) {
+		console.warn(missingDataMessage);
+	}
+	return properties;
 }
 
 /**
- * Get all layout sizes
+ * Get all layout sizes.
+ * CSS must be included so JavaScript can retrieve layout information.
+ * See the README for more information.
  * @return {Object} layout names and sizes
  */
 function getGridBreakpoints() {
-	return getGridFromDoc('before');
+	const breakpoints = getGridFromDoc('before');
+	if (Object.keys(breakpoints).length === 0) {
+		console.warn(missingDataMessage);
+	}
+	return breakpoints;
 }
 
 /**
@@ -34,7 +48,9 @@ function getGridFromDoc(position) {
 }
 
 /**
- * Grab the current layout
+ * Grab the current layout.
+ * CSS must be included so JavaScript can retrieve layout information.
+ * See the README for more information.
  * @return {String} Layout name
  */
 function getCurrentLayout() {
@@ -42,7 +58,9 @@ function getCurrentLayout() {
 }
 
 /**
- * Grab the current space between columns
+ * Grab the current space between columns.
+ * CSS must be included so JavaScript can retrieve layout information.
+ * See the README for more information.
  * @return {String} Gutter width in pixels
  */
 function getCurrentGutter() {
@@ -52,6 +70,8 @@ function getCurrentGutter() {
 /**
  * This sets MediaQueryListeners on all the o-grid breakpoints
  * and fires a `o-grid.layoutChange` event on layout change.
+ * CSS must be included so JavaScript can retrieve layout information.
+ * See the README for more information.
  */
 function enableLayoutChangeEvents() {
 	// Create a map containing all breakpoints exposed via html:before
@@ -103,7 +123,7 @@ function enableLayoutChangeEvents() {
 			}
 		});
 	} else {
-		console.error('To enable grid layout change events, include _oGridSurfaceLayoutSizes in your Sass');
+		console.error('Could not enable grid layout change events. Include o-grid css. See the README for more details.');
 	}
 }
 

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 const missingDataMessage = 'Could not find layout information. ' +
-	'You may need to include o-grid css. See the README ' +
+	'You may need to include o-grid css. See the README (https://registry.origami.ft.com/components/o-grid/readme) ' +
 	'for more information.';
 
 /**

--- a/main.scss
+++ b/main.scss
@@ -53,8 +53,9 @@
 	@if($current-layout) {
 		@include oGridSurfaceCurrentLayout;
 	}
+
 	@if($layout-sizes) {
-		@include _oGridSurfaceLayoutSizes;
+		@include oGridSurfaceLayoutSizes;
 	}
 
 	// Grid container

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -316,10 +316,6 @@
 
 /// Surface the layout currently displayed to make it readable in JS.
 ///
-/// In IE 8, assume it is `$o-grid-fixed-layout` (`L`).
-///
-/// **n.b.:** Only works when silent mode is off.
-///
 /// @example js
 ///  // your-app/main.js
 ///  // Return the current layout (e.g. default, S, M, L, XL)
@@ -352,8 +348,17 @@
 	flex-basis: oGridColspan($args...);
 }
 
-/// @access private
-@mixin _oGridSurfaceLayoutSizes {
+/// Surface the projects layouts (breakpoints) to make it readable in JS.
+///
+/// @example js
+///  // your-app/main.js
+///  // Return the layouts (e.g. {"layouts": {"S": "490px","M": "740px","L": "980px","XL": "1220px"}})
+///  import oGrid from 'o-grid';
+///  let breakpoints = oGrid.getGridBreakpoints();
+///  console.log(breakpoints);
+///
+/// @access public
+@mixin oGridSurfaceLayoutSizes {
 	html:before {
 		$combined: '{"layouts": {';
 


### PR DESCRIPTION
During the major cascade we [restored the `oGridSurfaceCurrentLayout`
mixin](https://github.com/Financial-Times/o-grid/pull/198) so the current layout could be exposed to JavaScript without
including any other o-grid css. We did this because, even with
no options set, the `oGrid` mixin outputs a lot of default CSS.

For the same reason this commit restores the
`oGridSurfaceLayoutSizes` mixin.

It also updates the README and warns in the console if a JS method
is used without including the required CSS.

Warnings refer to the README as users may be using SASS or the
Build Service, and it would be good to avoid shipping verbose
error messages to our users.