### PR TITLE
Restore the deprecated snappy mode by default feature.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -192,6 +192,9 @@
 		@each $layout-name in $_o-grid-layout-names {
 			@if index($_o-grid-layout-names, $layout-name) >= index($_o-grid-layout-names, $o-grid-start-snappy-mode-at) {
 				@include oGridRespondTo($layout-name) {
+					@if $grid-mode == 'snappy' {
+						max-width: map-get($o-grid-layouts, $layout-name);
+					}
 					@if $grid-mode == 'fluid' {
 						// If the grid mode is fluid, then use a class to make a row or a set of rows snappy
 						.o-grid-snappy &,


### PR DESCRIPTION
It was deleted by mistake here:
https://github.com/Financial-Times/o-grid/commit/5fbe04f4debd3b387939e4b5578acc2198178665#diff-bec94ad455c1c6700d76b841e9984f7cL195