### PR TITLE
Correct Sass test failure

### DIFF
--- a/test/scss/_base-grid.test.scss
+++ b/test/scss/_base-grid.test.scss
@@ -14,7 +14,7 @@
 				}
 
 				@include contains($selector: false) {
-					[data-o-grid-colspan~="full-width"] {
+					[data-o-grid-colspan~=full-width] {
 						display: block;
 						flex-basis: 100%;
 						min-width: 100%;
@@ -32,8 +32,8 @@
 				}
 
 				@include contains($selector: false) {
-					[data-o-grid-colspan~="push1"] {
-						left: 8.33333%;
+					[data-o-grid-colspan~=push1] {
+						left: 8.3333333333%;
 						right: auto;
 					}
 				}


### PR DESCRIPTION
We use dart sass for True Sass tests now in origami-build-tools v10,
which is likely the cause of this erroring now.