### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/js/layout-change-events.js
+++ b/demos/src/js/layout-change-events.js
@@ -1,4 +1,4 @@
-import { enableLayoutChangeEvents } from '../../../main';
+import { enableLayoutChangeEvents } from '../../../main.js';
 
 enableLayoutChangeEvents();
 

--- a/demos/src/js/style-switcher.js
+++ b/demos/src/js/style-switcher.js
@@ -1,9 +1,9 @@
 /*global $*/
 /*eslint no-extend-native: 0 */
 
-import almostEqual from './almost-equal';
-import { getCurrentGutter, getCurrentLayout } from '../../../main';
-import demoTypes from '../configurations.json';
+import almostEqual from './almost-equal.js';
+import { getCurrentGutter, getCurrentLayout } from '../../../main.js';
+import demoTypes from '../configurations.json.js';
 const local = /localhost|0\.0\.0\.0/.test(document.URL);
 
 // ============================================================================


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing