### PR TITLE
Restore snappy mode (de-deprecate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,9 +577,8 @@ $o-grid-gutters: (default: 10px, M: 20px);
 
 // Grid mode
 // - fluid: full width up to the largest layout's width
-// - snappy (deprecated): fluid width until the layout defined in $o-grid-start-snappy-mode-at (default: M),
+// - snappy  fluid width until the layout defined in $o-grid-start-snappy-mode-at (default: M),
 //           and then snaps into a larger fixed layout at each breakpoint
-//           (used by Next FT)
 // - fixed: always fixed-width with the layout defined by
 //          $o-grid-fixed-layout (default: L)
 $o-grid-mode: fluid (default) | snappy | fixed;
@@ -626,8 +625,6 @@ Products who need to add other breakpoints/layouts should use the helper `oGridA
 ```
 
 #### Snappy mode
-
-**Snappy mode is deprecated and will be removed in the next major version. Please talk to the Origami team if you would like to continue using snappy mode.**
 
 The container size can snap between fixed-widths as the viewport gets larger:
 

--- a/demos/src/scss/snappy.scss
+++ b/demos/src/scss/snappy.scss
@@ -1,4 +1,4 @@
-$o-grid-mode: 'snappy'; // deprecated, throws a warning
+$o-grid-mode: 'snappy';
 
 @import "common";
 

--- a/origami.json
+++ b/origami.json
@@ -30,10 +30,9 @@
 		},
 		{
 			"name": "snappy",
-			"title": "Deprecated: Snappy Grid",
+			"title": "Snappy Grid",
 			"sass": "demos/src/scss/snappy.scss",
-			"description": "Responsive grid that snaps between a larger fixed layout at each breakpoint",
-			"hidden": true
+			"description": "Responsive grid that snaps between a larger fixed layout at each breakpoint"
 		},
 		{
 			"name": "resized",

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -139,17 +139,6 @@
 /// @param {String} $grid-mode [$o-grid-mode]
 /// @param {Boolean} $bleed [false]
 @mixin oGridContainer($grid-mode: $o-grid-mode, $bleed: false) {
-	// If the grid mode is snappy, all rows should be snappy
-	// @breaking remove snappy mode in the next major release
-	@if $grid-mode == 'snappy' and not $_o-grid-mode-deprecation-warning-output {
-		@warn 'The "snappy" grid mode is deprecated and will be ' +
-			'removed in the next major version of o-grid. We ' +
-			'recommend using the default "fluid" grid instead. ' +
-			'Please contact the Origami team if you would like to ' +
-			'continue using the snappy grid.';
-		$_o-grid-mode-deprecation-warning-output: true !global;
-	}
-
 	box-sizing: border-box;
 	margin-left: auto;
 	margin-right: auto;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -83,8 +83,3 @@ $o-grid-gutters: (
 /// @access private
 /// @type Number
 $_o-grid-max-width: map-get($o-grid-layouts, nth($_o-grid-layout-names, -1));
-
-// Whether the deprecation warning for snappy mode has been output or not.
-/// @access private
-/// @type Boolean
-$_o-grid-mode-deprecation-warning-output: false !default;


### PR DESCRIPTION
The snappy grid is used in 3 important places on ft.com (not the app):
- front page
- stream page
- article page

There is no plan to update these pages at the moment to remove
the snappy grid, so the deprecation notice should be removed
as it is a nuisance and we will not be able to remove snappy
mode whilst it is still used by these pages. To deprecate
snappy mode in the future these pages must first be redesigned.
For example without the snappy grid stream page teasers may
become very long and difficult to read.

closes: https://github.com/Financial-Times/o-grid/issues/201