### PR TITLE
Fix `o-grid.layoutChange` for custom layouts (breakpoints)

### DIFF
--- a/main.js
+++ b/main.js
@@ -78,11 +78,10 @@ function enableLayoutChangeEvents() {
 	const gridLayouts = getGridBreakpoints();
 	if (gridLayouts.hasOwnProperty('layouts')) {
 		const layouts = gridLayouts.layouts;
-		const breakpoints = new Map([
-			...Object.keys(layouts).map(key => [key, layouts[key]]),
+		const breakpoints = [
+			...Object.entries(layouts),
 			['default', '240px']
-		]);
-		const decr1 = val => `${Number(val.replace('px', '') - 1)}px`;
+		].sort((a, b) => parseFloat(a[1]) - parseFloat(b[1]));
 
 		const setupQuery = (query, size) => {
 			// matchMedia listener handler: Dispatch `o-grid.layoutChange` event if a match
@@ -102,26 +101,22 @@ function enableLayoutChangeEvents() {
 		};
 
 		// Generate media queries for each
-		breakpoints.forEach((width, size) => {
-			switch(size) {
-				case 'S':
-					setupQuery(`(min-width: ${ width }) and (max-width: ${ decr1(breakpoints.get('M')) })`, size);
-					break;
-				case 'M':
-					setupQuery(`(min-width: ${ width }) and (max-width: ${ decr1(breakpoints.get('L')) })`, size);
-					break;
-				case 'L':
-					setupQuery(`(min-width: ${ width }) and (max-width: ${ decr1(breakpoints.get('XL')) })`, size);
-					break;
-				case 'XL':
-					setupQuery(`(min-width: ${ width })`, size);
-					break;
-				case 'default':
-				default:
-					setupQuery(`(max-width: ${ decr1(breakpoints.get('S')) })`, size);
-					break;
+		const decr1 = val => `${Number(val.replace('px', '') - 1)}px`;
+		for (let index = 0; index < breakpoints.length; index++) {
+			const breakpoint = breakpoints[index];
+			const isLast = index === breakpoints.length - 1;
+			const isFirst = index === 0
+			if (isFirst) {
+				setupQuery(`(max-width: ${breakpoint[1]})`, breakpoint[0]);
+				continue;
 			}
-		});
+			if (isLast) {
+				setupQuery(`(min-width: ${breakpoint[1]})`, breakpoint[0]);
+				continue;
+			}
+			const nextBreakpoint = breakpoints[index + 1];
+			setupQuery(`(min-width: ${breakpoint[1]}) and (max-width: ${decr1(nextBreakpoint[1])})`, breakpoint[0]);
+		}
 	} else {
 		console.error('Could not enable grid layout change events. Include o-grid css. See the README (https://registry.origami.ft.com/components/o-grid/readme) for more details.');
 	}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -32,6 +32,7 @@
 
 		$current-gutter-width: map-get($o-grid-gutters, $current-layout-name);
 
+		// Assumes all layouts use the same unit e.g. px or rem (as does the JavaScript)
 		@if not ($previous-layout-width > $layout-width or $current-layout-width < $layout-width) {
 			$temp-layouts: map-merge($temp-layouts, ($layout-name: $layout-width));
 			$temp-gutters: map-merge($temp-gutters, ($layout-name: $gutter-width));


### PR DESCRIPTION
It is possible to add a custom layout (breakpoint) to the grid:
```scss
@include oGridAddLayout(
	$layout-name: XS,
	$layout-width: 360px
);
```

However the `enableLayoutChangeEvents` method, which sets up event listeners to fire
when layouts change, did not correctly fire for custom layouts. It fired layout change events
for any custom layout when the `default` layout change is fired, regardless of the size of the
custom layout.

Now events are fired correctly for each layout, however this still depends on each layout having
the same CSS unit (px, rem, etc). Since `oGridAddLayout` currently throws an error if there
is a mismatch of units I think that's ok.

https://github.com/Financial-Times/o-grid/issues/286